### PR TITLE
fix(ci): declencher docker-publish sur push tag au lieu de release event

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,9 @@
 name: Docker Build & Push
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 env:
   REGISTRY: ghcr.io

--- a/docs/RELEASE_PIPELINE.md
+++ b/docs/RELEASE_PIPELINE.md
@@ -232,4 +232,4 @@ docker compose -f docker-compose.prod.yml logs -f web
 | `tests.yml` | Push / PR vers main, develop | Lance pytest et jest |
 | `commitlint.yml` | PR vers main, develop | Valide les messages de commit |
 | `release-please.yml` | Push vers main | Cree/met a jour une PR de release |
-| `docker-publish.yml` | Release GitHub publiee | Build et push des images GHCR |
+| `docker-publish.yml` | Push d'un tag `v*` | Build et push des images GHCR |


### PR DESCRIPTION
Le GITHUB_TOKEN utilise par release-please ne declenche pas les events release pour les autres workflows (protection anti-boucle GitHub). Utiliser le trigger push tags v* a la place.