### PR TITLE
feat(docker): supporter le build local dans docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,3 +1,9 @@
+# Deux modes de deploiement :
+#   1. Images GHCR (defaut) : docker compose -f docker-compose.prod.yml up -d
+#      Utilise les images pre-buildees depuis GitHub Container Registry.
+#   2. Build local : docker compose -f docker-compose.prod.yml up -d --build
+#      Construit les images localement a partir des Dockerfiles du projet.
+
 services:
   # Base de donnees PostgreSQL avec PostGIS
   db:
@@ -39,6 +45,9 @@ services:
   # Backend Django (gunicorn)
   web:
     image: ghcr.io/rnf-si/cicada-backend:${CICADA_VERSION:-latest}
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.prod
     container_name: cicada_prod_web
     environment:
       - DEBUG=False
@@ -83,6 +92,9 @@ services:
   # Frontend Angular (Apache)
   frontend:
     image: ghcr.io/rnf-si/cicada-frontend:${CICADA_VERSION:-latest}
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
     container_name: cicada_prod_frontend
     ports:
       - "${FRONTEND_PORT:-80}:80"
@@ -96,6 +108,9 @@ services:
   # Celery Worker
   celery-worker:
     image: ghcr.io/rnf-si/cicada-backend:${CICADA_VERSION:-latest}
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.prod
     container_name: cicada_prod_celery_worker
     environment:
       - DEBUG=False
@@ -134,6 +149,9 @@ services:
   # Celery Beat
   celery-beat:
     image: ghcr.io/rnf-si/cicada-backend:${CICADA_VERSION:-latest}
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.prod
     container_name: cicada_prod_celery_beat
     environment:
       - DEBUG=False

--- a/docs/RELEASE_PIPELINE.md
+++ b/docs/RELEASE_PIPELINE.md
@@ -189,6 +189,22 @@ Le fichier `docker-compose.prod.yml` contient 6 services :
 | `celery-worker` | `ghcr.io/rnf-si/cicada-backend` | Taches asynchrones |
 | `celery-beat` | `ghcr.io/rnf-si/cicada-backend` | Taches planifiees |
 
+### Deploiement sans images GHCR (build local)
+
+Si les images GHCR ne sont pas disponibles (CI/CD pas encore en place, test d'une version avant publication, ou deploiement sur un serveur sans acces au registry), il est possible de construire les images localement a partir du code source :
+
+```bash
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+Le fichier `docker-compose.prod.yml` contient a la fois les directives `image` et `build` pour les services custom. Le comportement de Docker Compose est le suivant :
+
+- **`docker compose pull`** : telecharge les images depuis GHCR (mode par defaut)
+- **`docker compose up -d --build`** : construit les images localement a partir des Dockerfiles, en ignorant les images distantes
+- **`docker compose up -d`** (sans `--build`) : utilise les images locales si elles existent, sinon tente un pull
+
+> **Note** : Le build local du frontend peut etre long car il inclut la compilation Angular. Assurez-vous d'avoir suffisamment de memoire (minimum 4 Go recommandes).
+
 ### Mise a jour vers une nouvelle version
 
 ```bash


### PR DESCRIPTION
Ajoute les directives build: aux services web, frontend, celery-worker et celery-beat pour permettre le déploiement sans images GHCR.