### PR TITLE
fix(deploy): rendre la redirection SSL configurable via ENABLE_SSL

### DIFF
--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -14,19 +14,21 @@ STATIC_ROOT = '/app/static/'
 MEDIA_ROOT = '/app/media/'
 
 # Security middleware
-SECURE_SSL_REDIRECT = True
+# Desactiver SSL_REDIRECT si pas de certificat SSL configure (ENABLE_SSL=false dans .env)
+_enable_ssl = os.environ.get('ENABLE_SSL', 'false').lower() == 'true'
+SECURE_SSL_REDIRECT = _enable_ssl
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 X_FRAME_OPTIONS = 'DENY'
-SECURE_HSTS_SECONDS = 31536000
-SECURE_HSTS_INCLUDE_SUBDOMAINS = True
-SECURE_HSTS_PRELOAD = True
+SECURE_HSTS_SECONDS = 31536000 if _enable_ssl else 0
+SECURE_HSTS_INCLUDE_SUBDOMAINS = _enable_ssl
+SECURE_HSTS_PRELOAD = _enable_ssl
 SECURE_REDIRECT_EXEMPT = [r'^api/health/$']
 
 # Session security
-SESSION_COOKIE_SECURE = True
-CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = _enable_ssl
+CSRF_COOKIE_SECURE = _enable_ssl
 SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_HTTPONLY = True
 


### PR DESCRIPTION
Sans certificat SSL, SECURE_SSL_REDIRECT=True bloquait l'accès à l'application en production. La variable d'environnement ENABLE_SSL (défaut: false) contrôle maintenant la redirection HTTPS, HSTS et les cookies sécurisés.