### PR TITLE
fix(email): respect EMAIL_USE_TLS env variable in production

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -30,5 +30,8 @@ EMAIL_HOST_USER=
 EMAIL_HOST_PASSWORD=
 DEFAULT_FROM_EMAIL=noreply@cicada.fr
 
+# --- Frontend (requis pour les liens dans les emails) ---
+SITE_URL=https://cicada.example.com
+
 # --- Ports ---
 FRONTEND_PORT=80

--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -92,7 +92,10 @@ CACHES = {
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = os.environ.get('EMAIL_HOST', '')
 EMAIL_PORT = int(os.environ.get('EMAIL_PORT', 587))
-EMAIL_USE_TLS = True
+EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS', 'true').lower() == 'true'
 EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', '')
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '')
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'noreply@outil-plan-gestion.fr')
+
+# URL du frontend (pour les liens dans les emails)
+SITE_URL = os.environ.get('SITE_URL', 'http://localhost:4200')

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -70,6 +70,7 @@ services:
       - EMAIL_HOST_USER=${EMAIL_HOST_USER:-}
       - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD:-}
       - DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL:-noreply@cicada.fr}
+      - SITE_URL=${SITE_URL:-http://localhost:4200}
     volumes:
       - media_files:/app/media
       - static_files:/app/static
@@ -131,6 +132,7 @@ services:
       - EMAIL_HOST_USER=${EMAIL_HOST_USER:-}
       - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD:-}
       - DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL:-noreply@cicada.fr}
+      - SITE_URL=${SITE_URL:-http://localhost:4200}
     volumes:
       - media_files:/app/media
       - logs_data:/app/logs


### PR DESCRIPTION
## Summary
- **fix(email)**: `EMAIL_USE_TLS` était codé en dur à `True` dans `production.py`, ignorant la variable d'environnement. Les serveurs SMTP sur port 25 sans TLS (ex: Altospam) échouaient silencieusement.
- Ajout de `SITE_URL` pour les liens dans les emails (containers web + celery-worker)

## Root cause
Le celery-worker tentait un STARTTLS sur un serveur SMTP port 25 qui ne le supporte pas → échec → retry 3x → abandon silencieux. Aucun email n'était envoyé.

## Test plan
- [ ] Vérifier que le celery-worker démarre correctement
- [ ] Tester l'inscription d'un utilisateur et vérifier la réception d'email
- [ ] Vérifier que les liens dans les emails pointent vers la bonne URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)