### PR TITLE
fix(redis): throttle résilient + séparation des Redis DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,11 +62,13 @@ REDIS_PORT=6379
 # Mot de passe Redis
 REDIS_PASSWORD=redis_password
 
-# Base de données Redis (0-15)
+# Bases de données Redis (0-15) - séparées pour éviter les interférences
+# DB 0 = Celery broker, DB 1 = Celery results, DB 2 = Django cache/throttle
 REDIS_DB=0
 
 # URL complète Redis (sera générée automatiquement si non définie)
 # REDIS_URL=redis://:redis_password@redis:6379/0
+# REDIS_CACHE_URL=redis://:redis_password@redis:6379/2
 
 # =============================================================================
 # Configuration des ports d'exposition
@@ -217,7 +219,7 @@ CELERY_BROKER_URL=redis://:redis_password@redis:6379/0
 
 # URL du backend de résultats Celery (Redis)
 # Stocke les résultats des tâches exécutées
-CELERY_RESULT_BACKEND=redis://:redis_password@redis:6379/0
+CELERY_RESULT_BACKEND=redis://:redis_password@redis:6379/1
 
 # =============================================================================
 # Configuration de logging

--- a/backend/apps/authentication/throttles.py
+++ b/backend/apps/authentication/throttles.py
@@ -1,11 +1,50 @@
 """
 Rate limiting pour les endpoints d'authentification.
 Protège contre les attaques par force brute sur login et register.
+
+Inclut des classes résilientes qui "fail open" en cas d'erreur Redis,
+pour éviter que le throttle ne bloque toutes les requêtes quand le cache
+est temporairement indisponible.
 """
-from rest_framework.throttling import AnonRateThrottle
+import logging
+
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
+
+logger = logging.getLogger('apps')
 
 
-class AuthRateThrottle(AnonRateThrottle):
+class ResilientUserRateThrottle(UserRateThrottle):
+    """
+    UserRateThrottle qui laisse passer les requêtes si Redis est indisponible.
+    Évite qu'une erreur Redis transitoire ne provoque des 500 sur toute l'API.
+    """
+
+    def allow_request(self, request, view):
+        try:
+            return super().allow_request(request, view)
+        except Exception:
+            logger.warning(
+                'Redis indisponible pour le throttle user — requête autorisée par défaut'
+            )
+            return True
+
+
+class ResilientAnonRateThrottle(AnonRateThrottle):
+    """
+    AnonRateThrottle qui laisse passer les requêtes si Redis est indisponible.
+    """
+
+    def allow_request(self, request, view):
+        try:
+            return super().allow_request(request, view)
+        except Exception:
+            logger.warning(
+                'Redis indisponible pour le throttle anon — requête autorisée par défaut'
+            )
+            return True
+
+
+class AuthRateThrottle(ResilientAnonRateThrottle):
     """
     Limite les tentatives de connexion et d'inscription.
     Rate configurable via DEFAULT_THROTTLE_RATES['auth'] dans settings.

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -194,8 +194,8 @@ REST_FRAMEWORK = {
     'EXCEPTION_HANDLER': 'apps.core.exception_handler.exception_handler',
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
     'DEFAULT_THROTTLE_CLASSES': [
-        'rest_framework.throttling.AnonRateThrottle',
-        'rest_framework.throttling.UserRateThrottle',
+        'apps.authentication.throttles.ResilientAnonRateThrottle',
+        'apps.authentication.throttles.ResilientUserRateThrottle',
     ],
     'DEFAULT_THROTTLE_RATES': {
         'anon': '200/hour',
@@ -210,7 +210,7 @@ CORS_ALLOWED_ORIGINS = os.environ.get('CORS_ALLOWED_ORIGINS', '').split(',') if 
 
 # Celery Configuration
 CELERY_BROKER_URL = os.environ.get('CELERY_BROKER_URL', 'redis://redis:6379/0')
-CELERY_RESULT_BACKEND = os.environ.get('CELERY_RESULT_BACKEND', 'redis://redis:6379/0')
+CELERY_RESULT_BACKEND = os.environ.get('CELERY_RESULT_BACKEND', 'redis://redis:6379/1')
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'

--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -86,13 +86,16 @@ CORS_ALLOW_ALL_ORIGINS = False
 CORS_ALLOWED_ORIGINS = [origin for origin in os.environ.get('CORS_ALLOWED_ORIGINS', '').split(',') if origin]
 
 # Cache configuration
+# DB 2 pour le cache Django (séparé du broker Celery DB 0 et results DB 1)
 CACHES = {
     'default': {
         'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': os.environ.get('REDIS_URL', 'redis://redis:6379/0'),
+        'LOCATION': os.environ.get('REDIS_CACHE_URL', 'redis://redis:6379/2'),
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-        }
+            'IGNORE_EXCEPTIONS': True,
+        },
+        'KEY_PREFIX': 'cicada',
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,10 +53,11 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-cicada_password}
       - POSTGRES_HOST=db
       - POSTGRES_PORT=5432
-      # Redis & Celery
+      # Redis & Celery (DB séparées : broker=0, results=1, cache=2)
       - REDIS_URL=redis://:${REDIS_PASSWORD:-redis_password}@redis:6379/0
+      - REDIS_CACHE_URL=redis://:${REDIS_PASSWORD:-redis_password}@redis:6379/2
       - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD:-redis_password}@redis:6379/0
-      - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD:-redis_password}@redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD:-redis_password}@redis:6379/1
       - ALLOWED_HOSTS=${ALLOWED_HOSTS:-localhost,127.0.0.1,web,frontend}
       - DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-config.settings.development}
       # Email - Mailpit par défaut en développement
@@ -133,7 +134,7 @@ services:
       - POSTGRES_PORT=5432
       - REDIS_URL=redis://:${REDIS_PASSWORD:-redis_password}@redis:6379/0
       - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD:-redis_password}@redis:6379/0
-      - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD:-redis_password}@redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD:-redis_password}@redis:6379/1
       - DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-config.settings.development}
       # Email - Mailpit par défaut en développement
       - EMAIL_BACKEND=${EMAIL_BACKEND:-django.core.mail.backends.smtp.EmailBackend}
@@ -189,7 +190,7 @@ services:
       - POSTGRES_PORT=5432
       - REDIS_URL=redis://:${REDIS_PASSWORD:-redis_password}@redis:6379/0
       - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD:-redis_password}@redis:6379/0
-      - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD:-redis_password}@redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD:-redis_password}@redis:6379/1
       - DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-config.settings.development}
     volumes:
       - ./backend:/app


### PR DESCRIPTION
## Summary
- **Throttle résilient** : les classes `ResilientUserRateThrottle` / `ResilientAnonRateThrottle` catchent les erreurs Redis et laissent passer la requête (fail open) au lieu de retourner un 500. Un warning est loggé.
- **Séparation des Redis DB** : broker Celery (DB 0), résultats Celery (DB 1), cache Django/throttle (DB 2) — évite les interférences entre Celery et le cache.
- **`IGNORE_EXCEPTIONS: True`** + `KEY_PREFIX` dans la config cache production.

Corrige le bug où un utilisateur perd l'affichage des modules après une action (ajout métrique, etc.) à cause d'une erreur Redis transitoire qui fait crasher le throttle middleware.

## Test plan
- [ ] Vérifier que l'app fonctionne normalement avec Redis actif
- [ ] Simuler une coupure Redis (`docker stop cicada_redis`) et vérifier que les requêtes API passent toujours (avec warning dans les logs)
- [ ] Vérifier que Celery fonctionne avec la nouvelle DB (résultats sur DB 1)
- [ ] Vérifier que le cache fonctionne sur DB 2
- [ ] Tester l'ajout d'une métrique puis retour accueil → modules visibles

🤖 Generated with [Claude Code](https://claude.com/claude-code)