### PR TITLE
fix(enjeux): OLT non affichés sur la page de synthèse (#191)

### DIFF
--- a/frontend/src/app/features/plans/plan-detail.component.ts
+++ b/frontend/src/app/features/plans/plan-detail.component.ts
@@ -140,21 +140,24 @@ export class PlanDetailComponent implements OnInit, OnDestroy {
   fcrData = signal<Enjeu[]>([]);
   enjeuxLoading = signal(false);
 
-  // Aggregated OLT/OO across all enjeux
+  // Aggregated OLT/OO across all enjeux AND FCR (#191 — les OLT créés
+  // sur un FCR doivent aussi apparaître dans la synthèse).
   allOlts = computed(() => {
-    return this.enjeuxData().flatMap(enjeu =>
-      (enjeu.objectifs_long_terme || []).map(olt => ({
+    const items = [...this.enjeuxData(), ...this.fcrData()];
+    return items.flatMap(item =>
+      (item.objectifs_long_terme || []).map(olt => ({
         ...olt,
-        enjeu_libelle: enjeu.libelle,
-        enjeu_id: enjeu.id_enjeu
+        enjeu_libelle: item.libelle,
+        enjeu_id: item.id_enjeu
       }))
     );
   });
 
   allOos = computed(() => {
     const seen = new Set<number>();
-    return this.enjeuxData().flatMap(enjeu =>
-      (enjeu.facteurs_influence || []).flatMap(fi =>
+    const items = [...this.enjeuxData(), ...this.fcrData()];
+    return items.flatMap(item =>
+      (item.facteurs_influence || []).flatMap(fi =>
         (fi.pressions || []).flatMap(p =>
           (p.objectifs_operationnels || [])
             .filter(oo => {
@@ -164,8 +167,8 @@ export class PlanDetailComponent implements OnInit, OnDestroy {
             })
             .map(oo => ({
               ...oo,
-              enjeu_libelle: enjeu.libelle,
-              enjeu_id: enjeu.id_enjeu
+              enjeu_libelle: item.libelle,
+              enjeu_id: item.id_enjeu
             }))
         )
       )
@@ -233,24 +236,27 @@ export class PlanDetailComponent implements OnInit, OnDestroy {
   });
 
   // Accordéons de la section Synthèse
+  // #191 — Tous les accordéons de la synthèse sont ouverts par défaut
+  // pour que les utilisateurs voient immédiatement les OLT et OO créés
+  // (sinon les utilisateurs pensent qu'ils ne s'affichent pas).
   syntheseAccordions = signal<SyntheseAccordion[]>([
     {
       id: 'enjeux',
       title: 'Enjeux et Facteurs clés de réussite',
       colorClass: 'terra-cotta',
-      expanded: false
+      expanded: true
     },
     {
       id: 'objectifs-lt',
       title: 'Objectifs long terme',
       colorClass: 'terra-cotta',
-      expanded: false
+      expanded: true
     },
     {
       id: 'objectifs-op',
       title: 'Objectifs opérationnels',
       colorClass: 'terra-cotta',
-      expanded: false
+      expanded: true
     },
     {
       id: 'actions',


### PR DESCRIPTION
## Problème

Retour utilisateur #45 : « Les OLT (Objectifs Long Terme) créés ne s'affichent pas sur la page de synthèse du plan de gestion. »

## Causes identifiées

1. **Accordéons fermés par défaut**. Sur la page synthèse d'un plan, seuls les accordéons « Actions et suivis » étaient ouverts à l'arrivée. Les sections « Enjeux et FCR », « Objectifs long terme » et « Objectifs opérationnels » étaient repliées. L'utilisateur ne voyait pas ses OLT/OO créés et concluait qu'ils n'existaient pas.
2. **OLT/OO sur les FCR ignorés**. `allOlts()` et `allOos()` itèraient uniquement `enjeuxData`, pas `fcrData`. Un OLT créé sur un FCR n'apparaissait nulle part en synthèse.

## Changements

- `plan-detail.component.ts` :
  - `syntheseAccordions` initialisés avec `expanded: true` pour tous les accordéons.
  - `allOlts()` et `allOos()` fusionnent désormais `[...enjeuxData(), ...fcrData()]`.

Tests Jest plan-detail (60/60) verts.

## Test plan

- [ ] Ouvrir un plan dense (Camargue 25 enjeux, Lacs zones humides 8 enjeux). À l'arrivée sur le détail, les 4 accordéons synthèse sont ouverts.
- [ ] Vérifier que les OLT existants des enjeux apparaissent dans la section « Objectifs long terme ».
- [ ] Créer un OLT sur un FCR (si possible) → il apparaît aussi dans cette section.
- [ ] Idem pour les OO sur les FCR dans la section « Objectifs opérationnels ».