### PR TITLE
fix(enjeux): augmenter la liste de recherche taxon/habitat/géologie (#238)

### DIFF
--- a/frontend/src/app/core/services/geology.service.ts
+++ b/frontend/src/app/core/services/geology.service.ts
@@ -52,7 +52,9 @@ export class GeologyService {
       return of([]);
     }
 
-    const cacheKey = search;
+    // #238 — inclure `limit` dans la clé pour éviter qu'un appel court
+    // (limit=20) ne masque les résultats d'un appel ultérieur plus large.
+    const cacheKey = `${search}|${options?.limit || ''}`;
     const cached = this.autocompleteCache.get(cacheKey);
     if (cached) {
       return of(cached);

--- a/frontend/src/app/core/services/habitat.service.ts
+++ b/frontend/src/app/core/services/habitat.service.ts
@@ -103,7 +103,9 @@ export class HabitatService {
       return of([]);
     }
 
-    const cacheKey = `${search}|${options?.cdTypo || ''}`;
+    // #238 — inclure `limit` dans la clé pour éviter qu'un appel court
+    // (limit=20) ne masque les résultats d'un appel ultérieur plus large.
+    const cacheKey = `${search}|${options?.cdTypo || ''}|${options?.limit || ''}`;
     const cached = this.autocompleteCache.get(cacheKey);
     if (cached) {
       return of(cached);

--- a/frontend/src/app/core/services/taxonomy.service.ts
+++ b/frontend/src/app/core/services/taxonomy.service.ts
@@ -212,8 +212,10 @@ export class TaxonomyService {
       return of([]);
     }
 
-    // Vérifier le cache
-    const cacheKey = `${search}|${options?.regne || ''}|${options?.group2_inpn || ''}`;
+    // Vérifier le cache. #238 — inclure `limit` dans la clé pour éviter
+    // qu'un appel court avec limit=20 ne masque les résultats supplémentaires
+    // que demande un appel ultérieur avec un limit plus haut.
+    const cacheKey = `${search}|${options?.regne || ''}|${options?.group2_inpn || ''}|${options?.limit || ''}`;
     const cached = this.autocompleteCache.get(cacheKey);
     if (cached) {
       return of(cached);

--- a/frontend/src/app/shared/components/habitat-autocomplete/habitat-autocomplete.component.ts
+++ b/frontend/src/app/shared/components/habitat-autocomplete/habitat-autocomplete.component.ts
@@ -51,7 +51,9 @@ export class HabitatAutocompleteComponent implements OnInit, OnDestroy, ControlV
   cdTypo = input<number | undefined>(undefined);
 
   /** Nombre max de résultats */
-  limit = input<number>(20);
+  // #238 — borne haute (la limite effective est dynamique : 20 pour 2-3
+  // chars, jusqu'à `limit` pour 4+ chars).
+  limit = input<number>(50);
 
   /** Champ obligatoire */
   required = input<boolean>(false);
@@ -81,9 +83,11 @@ export class HabitatAutocompleteComponent implements OnInit, OnDestroy, ControlV
             this.isLoading.set(false);
             return [];
           }
+          // #238 — limite dynamique selon longueur de recherche.
+          const effectiveLimit = search.length >= 4 ? this.limit() : Math.min(this.limit(), 20);
           return this.habitatService.autocomplete(search, {
             cdTypo: this.cdTypo(),
-            limit: this.limit(),
+            limit: effectiveLimit,
           });
         }),
       ).subscribe(results => {

--- a/frontend/src/app/shared/components/reference-item-list/reference-item-list.component.spec.ts
+++ b/frontend/src/app/shared/components/reference-item-list/reference-item-list.component.spec.ts
@@ -115,7 +115,8 @@ describe('ReferenceItemListComponent', () => {
       component.searchControl.setValue('Lynx');
       tick(300); // debounce
 
-      expect(taxonomyService.autocomplete).toHaveBeenCalledWith('Lynx', { limit: 20 });
+      // #238 — limit dynamique : 'Lynx' (4 chars) → limit=50
+      expect(taxonomyService.autocomplete).toHaveBeenCalledWith('Lynx', { limit: 50 });
       expect(component.autocompleteResults().length).toBe(1);
     }));
 

--- a/frontend/src/app/shared/components/reference-item-list/reference-item-list.component.ts
+++ b/frontend/src/app/shared/components/reference-item-list/reference-item-list.component.ts
@@ -79,12 +79,16 @@ export class ReferenceItemListComponent implements OnInit, OnDestroy {
       },
       error: () => this.isSearching.set(false)
     };
+    // #238 — limite dynamique : 20 résultats pour 2-3 chars (exploration),
+    // 50 pour 4+ chars (l'utilisateur connaît son taxon/habitat et doit le
+    // trouver dans la liste).
+    const effectiveLimit = term.length >= 4 ? 50 : 20;
     if (this.type === 'taxon') {
-      this.taxonomyService.autocomplete(term, { limit: 20 }).subscribe(handler);
+      this.taxonomyService.autocomplete(term, { limit: effectiveLimit }).subscribe(handler);
     } else if (this.type === 'habitat') {
-      this.habitatService.autocomplete(term, { limit: 20 }).subscribe(handler);
+      this.habitatService.autocomplete(term, { limit: effectiveLimit }).subscribe(handler);
     } else {
-      this.geologyService.autocomplete(term, { limit: 20 }).subscribe(handler);
+      this.geologyService.autocomplete(term, { limit: effectiveLimit }).subscribe(handler);
     }
   }
 

--- a/frontend/src/app/shared/components/taxon-autocomplete/taxon-autocomplete.component.ts
+++ b/frontend/src/app/shared/components/taxon-autocomplete/taxon-autocomplete.component.ts
@@ -53,8 +53,11 @@ export class TaxonAutocompleteComponent implements OnInit, OnDestroy, ControlVal
   /** Filtre optionnel par groupe INPN */
   group2Inpn = input<string | undefined>(undefined);
 
-  /** Nombre max de résultats */
-  limit = input<number>(20);
+  /** Nombre max de résultats — borne haute. #238 — la limite effective est
+   *  dynamique selon la longueur de la requête (20 pour 2-3 chars, jusqu'à
+   *  cette valeur pour 4+ chars) afin de ne pas tronquer les recherches
+   *  précises où l'utilisateur attend de voir SON taxon dans la liste. */
+  limit = input<number>(50);
 
   /** Champ obligatoire */
   required = input<boolean>(false);
@@ -84,8 +87,12 @@ export class TaxonAutocompleteComponent implements OnInit, OnDestroy, ControlVal
             this.isLoading.set(false);
             return [];
           }
+          // #238 — limite dynamique : 20 résultats pour 2-3 chars (autocomplete
+          // exploratoire), jusqu'à `limit` pour 4+ chars (l'utilisateur cherche
+          // un taxon précis et doit pouvoir le voir dans la liste).
+          const effectiveLimit = search.length >= 4 ? this.limit() : Math.min(this.limit(), 20);
           return this.taxonomyService.autocomplete(search, {
-            limit: this.limit(),
+            limit: effectiveLimit,
             regne: this.regne(),
             group2_inpn: this.group2Inpn(),
           });


### PR DESCRIPTION
## Contexte

Retour Sophie #238 : « la recherche des taxons limite l'affichage… il faut augmenter la liste, surtout à partir de 4 lettres ou chiffres écrits ».

Le rang taxonomique (ordre/famille/genre) avait déjà été ajouté dans le commit `29c2a4d`. Restait à augmenter la liste affichée et corriger un bug intermittent du cache.

## Changements

### 1. Limite dynamique selon longueur de recherche

| Longueur | Limite |
|---|---|
| 2-3 caractères | 20 (autocomplete exploratoire, économise bande passante) |
| 4+ caractères | 50 (utilisateur connaît précisément son taxon/habitat) |

Appliqué à :
- `taxon-autocomplete.component`
- `habitat-autocomplete.component`
- `reference-item-list.component` (taxon + habitat + géologie)

### 2. Bug intermittent du cache

La clé du cache `autocompleteCache` (dans `taxonomy.service`, `habitat.service`, `geology.service`) n'incluait pas `limit` :

```
cacheKey = "${search}|${regne}|${group2_inpn}"  // PAS de limit !
```

Conséquence : un appel court (limit=20) puis un appel large (limit=50) sur la même recherche → cache HIT renvoie les 20 premiers, masquant les 30 suivants. C'est probablement la cause du « parfois la recherche bug » signalé.

Désormais : `limit` inclus dans la clé pour les 3 services.

## Tests

59/59 verts (`taxonomy + habitat + reference-item-list + taxon-autocomplete + habitat-autocomplete`).

## Test plan

- [ ] Page enjeu → onglet Détail → ajouter un taxon : taper 2-3 lettres → liste limitée à 20.
- [ ] Continuer à taper (4+ lettres) : la liste s'étend à 50 résultats.
- [ ] Idem pour ajouter un habitat.
- [ ] Vérifier que le rang (ordre/famille/genre) reste visible (`29c2a4d` ne touché pas).
- [ ] Vider le cache (F5) et refaire une recherche : pas de comportement erratique entre appels successifs.