### PR TITLE
fix(enjeux): pression et FI sur 2 lignes distinctes dans les OO (#236)

### DIFF
--- a/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.html
+++ b/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.html
@@ -2103,19 +2103,27 @@
                         <p class="olt-description">{{ oo.description }}</p>
                       }
 
-                      <!-- Pressions associées (M2M) -->
+                      <!-- Pressions et facteurs d'influence associés (M2M).
+                           #236 — affichage sur 2 lignes distinctes (Sophie) :
+                           1) « Pression(s) associée(s) : »
+                           2) « Facteur(s) d'influence : » (dédupliqué) -->
                       @if (oo.pressions && oo.pressions.length > 0) {
                         <div class="oo-pressions-chips">
                           <span class="oo-pressions-label">{{ 'enjeux.oo.pressionLabel' | translate }} :</span>
                           @for (p of oo.pressions; track p.id_pression) {
-                            <span class="oo-pression-chip" [title]="p.facteur_influence_libelle ? ('enjeux.oo.facteurDescription' | translate) + ' : ' + p.facteur_influence_libelle : ''">
-                              @if (p.facteur_influence_libelle) {
-                                <span class="oo-pression-chip-facteur">{{ p.facteur_influence_libelle }} ›</span>
-                              }
-                              {{ p.libelle }}
-                            </span>
+                            <span class="oo-pression-chip">{{ p.libelle }}</span>
                           }
                         </div>
+                        @if (uniqueFacteursFromOO(oo); as facteurs) {
+                          @if (facteurs.length > 0) {
+                            <div class="oo-pressions-chips oo-facteurs-chips">
+                              <span class="oo-pressions-label">{{ 'enjeux.oo.facteursAssocies' | translate }} :</span>
+                              @for (fi of facteurs; track fi) {
+                                <span class="oo-facteur-chip">{{ fi }}</span>
+                              }
+                            </div>
+                          }
+                        }
                       }
 
                       <!-- Résultats attendus -->

--- a/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.scss
+++ b/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.scss
@@ -904,6 +904,25 @@
   font-size: $font-size-small;
 }
 
+// #236 — Ligne distincte pour les facteurs d'influence sous les pressions.
+// Margin-top négatif pour rapprocher visuellement les 2 lignes (même bloc
+// conceptuel "Pressions + leurs FI") tout en gardant la lisibilité.
+.oo-facteurs-chips {
+  margin-top: -$spacing-xs;
+}
+
+.oo-facteur-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-xxs;
+  background-color: rgba($secondary-terra-cotta, 0.08);
+  color: $secondary-terra-cotta;
+  font-size: $font-size-small;
+  padding: 2px $spacing-sm;
+  border-radius: $border-radius-pill;
+  border: 1px dashed rgba($secondary-terra-cotta, 0.3);
+}
+
 // Note d'usage en haut de l'onglet
 .olt-info-note {
   display: flex;

--- a/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.ts
+++ b/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.ts
@@ -2558,6 +2558,24 @@ export class EnjeuxListComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * #236 — Extrait les libellés uniques des facteurs d'influence rattachés
+   * aux pressions d'un OO. Préserve l'ordre d'apparition (premier rencontré
+   * = premier affiché).
+   */
+  uniqueFacteursFromOO(oo: ObjectifOperationnel): string[] {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const p of (oo.pressions || [])) {
+      const lib = (p as any).facteur_influence_libelle;
+      if (lib && !seen.has(lib)) {
+        seen.add(lib);
+        out.push(lib);
+      }
+    }
+    return out;
+  }
+
+  /**
    * Drag-and-drop : réordonne les actions/opérations d'une métrique (#228).
    * Le code calculé (CS1, IP2, ...) se met à jour automatiquement après
    * la recharge — le rang est plan-wide, donc déplacer une action peut

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -2301,6 +2301,7 @@
       "facteurLabel": "Facteur d'influence",
       "facteurDescription": "Facteur d'influence",
       "pressionLabel": "Pression(s) associée(s)",
+      "facteursAssocies": "Facteur(s) d'influence",
       "addButton": "Ajouter un objectif opérationnel",
       "newTitle": "Nouvel objectif opérationnel",
       "editTitle": "Modifier l'objectif opérationnel",


### PR DESCRIPTION
## Contexte

Retour Sophie #236 : la carte d'un OO déplié affichait les **pressions ET les facteurs d'influence dans le même chip** (« FI › pression »), alors que le label disait « Pression(s) associée(s) ». Demande : faire 2 lignes distinctes (pression d'abord, FI ensuite).

## Changements

Sous chaque OO déplié :
- **Ligne 1** : `Pression(s) associée(s) :` puis chips beiges des pressions
- **Ligne 2** : `Facteur(s) d'influence :` puis chips terra-cotta pointillées des FI (dédupliqués)

Helper TS `uniqueFacteursFromOO(oo)` qui extrait les libellés uniques de FI depuis le M2M `oo.pressions` en préservant l'ordre d'apparition.

Nouvelle clé i18n `enjeux.oo.facteursAssocies` = « Facteur(s) d'influence ».

## Tests

Jest enjeux-list : **146/146 verts**.

## Test plan

- [ ] Ouvrir un plan en brouillon → un enjeu avec FI → pression → OO.
- [ ] Onglet OLT/OO → dérouler un OO.
- [ ] Vérifier 2 lignes :
  1. « Pression(s) associée(s) : » suivi de chips beiges (juste les libellés de pression)
  2. « Facteur(s) d'influence : » suivi de chips terra-cotta pointillées (un seul chip si plusieurs pressions partagent le même FI — dédupliqué)
- [ ] Pas d'erreur visuelle quand OO sans pressions (les 2 lignes disparaissent ensemble).