### PR TITLE
feat(enjeux): numérotation globale des OLT à travers les enjeux (#229)

### DIFF
--- a/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.html
+++ b/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.html
@@ -731,7 +731,7 @@
                               </button>
                             }
                             <app-section-title
-                              [title]="('enjeux.olt.label' | translate) + ' ' + (idx + 1) + ' : ' + olt.libelle"
+                              [title]="('enjeux.olt.label' | translate) + ' ' + (getOltGlobalNumber(olt.id_olt) || idx + 1) + ' : ' + olt.libelle"
                               [tooltip]="'enjeux.olt.tooltip' | translate"
                               icon="fi-rr-eye"
                               ellipseColor="terra-cotta"

--- a/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.ts
+++ b/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.ts
@@ -297,6 +297,40 @@ export class EnjeuxListComponent implements OnInit, OnDestroy {
     return [...(data.fcr || [])].sort(EnjeuxListComponent._byOrdreId);
   });
 
+  /**
+   * #229 — Numérotation globale des OLT à travers tous les enjeux du plan,
+   * dans l'ordre de tri des enjeux (`ordre`, puis `id_enjeu`).
+   *
+   * Exemple : enjeu 1 a 2 OLT → OLT 1 et OLT 2 ; enjeu 2 a 2 OLT → OLT 3
+   * et OLT 4. Permet aux gestionnaires de désigner un OLT par son numéro
+   * sans ambiguïté.
+   */
+  oltGlobalRank = computed<Map<number, number>>(() => {
+    const map = new Map<number, number>();
+    let rank = 0;
+    for (const enjeu of this.enjeux()) {
+      for (const olt of enjeu.objectifs_long_terme || []) {
+        rank += 1;
+        map.set(olt.id_olt, rank);
+      }
+    }
+    // Les FCR n'ont en principe pas d'OLT, mais on les inclut pour cohérence
+    // au cas où un FCR en porterait (le numérotage global continue).
+    for (const enjeu of this.fcr()) {
+      for (const olt of enjeu.objectifs_long_terme || []) {
+        rank += 1;
+        map.set(olt.id_olt, rank);
+      }
+    }
+    return map;
+  });
+
+  /** #229 — Retourne le numéro global d'un OLT (1-based) ou null si inconnu. */
+  getOltGlobalNumber(oltId: number | undefined): number | null {
+    if (oltId === undefined) return null;
+    return this.oltGlobalRank().get(oltId) ?? null;
+  }
+
   // Compteur total
   totalCount = computed(() => {
     const data = this.planEnjeuxData();


### PR DESCRIPTION
## Contexte

Retour Sophie #229 : numérotation actuelle des OLT locale à chaque enjeu → 2 OLT sur l'enjeu 1 sont appelés « OLT 1 » et « OLT 2 », puis sur l'enjeu 2 on a aussi « OLT 1 » et « OLT 2 ». Source d'ambiguïté.

Demande :
> Enjeu 1 a 2 OLT → OLT 1 et OLT 2
> Enjeu 2 a 2 OLT → OLT 3 et OLT 4

## Changements

- `oltGlobalRank` computed signal qui construit une `Map<id_olt, rank>` en parcourant les enjeux dans l'ordre métier (`ordre` ASC puis `id_enjeu` ASC), puis les FCR (pour cohérence si un FCR porte un OLT).
- Helper `getOltGlobalNumber(oltId)` exposé au template.
- Le titre d'OLT (`app-section-title`) utilise désormais le numéro global au lieu de l'index local. Fallback sur l'index local au cas où l'OLT manquerait du mapping.

Tests Jest enjeux-list : **146/146 verts**.

## Test plan

- [ ] Ouvrir un plan avec plusieurs enjeux ayant chacun ≥ 1 OLT.
- [ ] Vérifier que les OLT du 1er enjeu commencent à 1, et que ceux du 2e enjeu continuent (3, 4, …).
- [ ] Réordonner les enjeux (DnD) → la numérotation OLT suit l'ordre des enjeux.
- [ ] Créer un nouvel OLT sur un enjeu : il prend le numéro suivant dans la chaîne globale.