### PR TITLE
feat(design): fondations revue design - Nunito, chevrons, couleurs, composant Tag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,40 @@ Les composants standalone sont dans `frontend/src/app/shared/components/`.
 - `realized-unplanned`: Cercle + ✗ (réalisée non prévue)
 - `partial-unplanned`: Demi-cercle + ✗ (partiellement réalisée non prévue)
 
+#### `TagComponent` (#296)
+**Sélecteur**: `app-tag`
+**Fichiers**: `tag/`
+**Description**: Tag unifié (pill, sans bordure, padding compact). Remplace `.status-*`, `.score-*`, et les `<mat-chip>` pour les statuts. Issue #296.
+
+```html
+<!-- Statut simple -->
+<app-tag variant="success" label="Validé"></app-tag>
+
+<!-- Avec icône -->
+<app-tag variant="warning" label="En attente" icon="fi-rr-clock"></app-tag>
+
+<!-- Cliquable -->
+<app-tag variant="draft" label="Brouillon" [clickable]="true" (click)="onEdit()"></app-tag>
+```
+
+| Input | Type | Défaut | Description |
+|-------|------|--------|-------------|
+| `variant` | `TagVariant` | `'neutral'` | Voir liste ci-dessous |
+| `label` | `string` | `''` | Texte du tag |
+| `icon` | `string?` | — | Classe Flaticon optionnelle (ex: `'fi-rr-check'`) |
+| `size` | `'sm' \| 'md'` | `'md'` | Taille (sm pour tableaux denses) |
+| `clickable` | `boolean` | `false` | Active curseur pointer + effet hover |
+
+**Variantes disponibles** :
+- Sémantiques (texte blanc, AA) : `success` (vert #04854B), `error` (rouge #E12329), `info`/`primary` (bleu-vert #025359)
+- Décoratives (texte noir, AA) : `warning` (saumon #F5B399), `draft` (jaune #FEC180), `neutral` (vert pâle #C0E3CF), `muted` (gris clair)
+- Scores (texte noir, AA) : `score-very-bad`, `score-bad`, `score-neutral`, `score-good`, `score-very-good`
+
+**Règles** :
+- Pas de bordure par défaut
+- Pas de hover si `clickable=false`
+- Combinaisons WCAG AA respectées — voir [docs/DESIGN_SYSTEM.md](docs/DESIGN_SYSTEM.md)
+
 #### `HeaderComponent`
 **Sélecteur**: `app-header`
 **Fichiers**: `header/`

--- a/frontend/src/app/features/admin/admin-modules/admin-modules.component.ts
+++ b/frontend/src/app/features/admin/admin-modules/admin-modules.component.ts
@@ -355,7 +355,7 @@ interface UserWithModuleAccess {
     .subtitle {
       font-family: 'Nunito', sans-serif;
       font-size: 16px;
-      color: #5C5C5C;
+      color: #746F6E;
       margin: 0;
     }
 
@@ -389,7 +389,7 @@ interface UserWithModuleAccess {
       p {
         font-family: 'Nunito', sans-serif;
         font-size: 13px;
-        color: #5C5C5C;
+        color: #746F6E;
         margin: 0;
         line-height: 1.5;
       }
@@ -476,7 +476,7 @@ interface UserWithModuleAccess {
       p {
         font-family: 'Nunito', sans-serif;
         font-size: 13px;
-        color: #5C5C5C;
+        color: #746F6E;
         margin: 0;
         line-height: 1.4;
       }
@@ -492,7 +492,7 @@ interface UserWithModuleAccess {
         align-items: center;
         gap: 6px;
         font-size: 13px;
-        color: #5C5C5C;
+        color: #746F6E;
 
         i {
           font-size: 14px;
@@ -573,7 +573,7 @@ interface UserWithModuleAccess {
       align-items: center;
       gap: 12px;
       padding: 16px;
-      color: #5C5C5C;
+      color: #746F6E;
       font-size: 14px;
     }
 
@@ -632,7 +632,7 @@ interface UserWithModuleAccess {
     .user-email {
       font-family: 'Nunito', sans-serif;
       font-size: 12px;
-      color: #5C5C5C;
+      color: #746F6E;
     }
 
     .user-org {
@@ -714,7 +714,7 @@ interface UserWithModuleAccess {
       p {
         font-family: 'Nunito', sans-serif;
         font-size: 14px;
-        color: #5C5C5C;
+        color: #746F6E;
         margin: 0;
       }
     }
@@ -731,7 +731,7 @@ interface UserWithModuleAccess {
         font-family: 'Nunito', sans-serif;
         font-size: 13px;
         font-weight: 700;
-        color: #5C5C5C;
+        color: #746F6E;
         text-transform: uppercase;
         letter-spacing: 0.02em;
         background-color: #F8F5F1;
@@ -755,7 +755,7 @@ interface UserWithModuleAccess {
 
     .justification {
       font-size: 13px;
-      color: #5C5C5C;
+      color: #746F6E;
       max-width: 300px;
       overflow: hidden;
       text-overflow: ellipsis;

--- a/frontend/src/app/features/admin/admin-settings/admin-settings.component.scss
+++ b/frontend/src/app/features/admin/admin-settings/admin-settings.component.scss
@@ -10,7 +10,7 @@
 }
 
 .page-title {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: 25px;
   font-weight: 700;
   color: $primary-color;
@@ -18,7 +18,7 @@
 }
 
 .page-subtitle {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-base;
   font-weight: 400;
   color: $gray-dark;
@@ -37,7 +37,7 @@
 }
 
 .section-title {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-h4;
   font-weight: 700;
   color: $primary-color;
@@ -53,7 +53,7 @@
 }
 
 .section-description {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-small;
   font-weight: 400;
   color: $gray-dark;
@@ -104,7 +104,7 @@
     left: 11px;
     background: $secondary-yellow;
     color: $black;
-    font-family: 'Nunito', sans-serif;
+    font-family: $font-family;
     font-size: 11px;
     font-weight: 700;
     padding: $spacing-xxs $spacing-sm;
@@ -122,7 +122,7 @@
   display: flex;
   align-items: center;
   gap: $spacing-xs;
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-small;
   font-weight: 600;
 
@@ -140,7 +140,7 @@
 }
 
 .image-meta {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: 12px;
   font-weight: 400;
   color: $gray;
@@ -155,7 +155,7 @@
   margin-top: $spacing-xs;
 
   .position-label {
-    font-family: 'Nunito', sans-serif;
+    font-family: $font-family;
     font-size: $font-size-small;
     font-weight: 600;
     color: $black;
@@ -166,7 +166,7 @@
     border: 1px solid $gray-light;
 
     mat-button-toggle {
-      font-family: 'Nunito', sans-serif;
+      font-family: $font-family;
       font-size: 12px;
 
       i {
@@ -182,7 +182,7 @@
   }
 
   .position-hint {
-    font-family: 'Nunito', sans-serif;
+    font-family: $font-family;
     font-size: 11px;
     font-weight: 400;
     color: $gray;
@@ -218,7 +218,7 @@
     gap: $spacing-xs;
     background: $primary-color;
     color: $white;
-    font-family: 'Nunito', sans-serif;
+    font-family: $font-family;
     font-size: $font-size-small;
     font-weight: 600;
     padding: 10px 18px;

--- a/frontend/src/app/features/admin/admin-update/admin-update.component.scss
+++ b/frontend/src/app/features/admin/admin-update/admin-update.component.scss
@@ -10,7 +10,7 @@
 }
 
 .page-title {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: 25px;
   font-weight: 700;
   color: $primary-color;
@@ -18,7 +18,7 @@
 }
 
 .page-subtitle {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-base;
   font-weight: 400;
   color: $gray-dark;
@@ -44,7 +44,7 @@
 }
 
 .section-title {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: 18px;
   font-weight: 600;
   color: $gray-dark;

--- a/frontend/src/app/features/auth/login.component.scss
+++ b/frontend/src/app/features/auth/login.component.scss
@@ -38,7 +38,7 @@ h1 {
 
 .subtitle {
   font-size: $font-size-base;
-  color: #6c757d;
+  color: $gray-dark;
   margin: 0;
 }
 
@@ -100,7 +100,7 @@ h1 {
 
 .register-link {
   font-size: $font-size-small;
-  color: #6c757d;
+  color: $gray-dark;
   margin: 0 0 16px 0;
 
   a {
@@ -118,7 +118,7 @@ h1 {
   display: inline-flex;
   align-items: center;
   gap: $spacing-xs;
-  color: #6c757d;
+  color: $gray-dark;
   text-decoration: none;
   font-size: $font-size-small;
   transition: color 0.2s;

--- a/frontend/src/app/features/auth/login.component.scss
+++ b/frontend/src/app/features/auth/login.component.scss
@@ -29,7 +29,7 @@
 }
 
 h1 {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: 25px;
   font-weight: 700;
   color: #025359;

--- a/frontend/src/app/features/auth/register.component.scss
+++ b/frontend/src/app/features/auth/register.component.scss
@@ -29,7 +29,7 @@
 }
 
 h1 {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: 25px;
   font-weight: 700;
   color: #025359;

--- a/frontend/src/app/features/auth/register.component.scss
+++ b/frontend/src/app/features/auth/register.component.scss
@@ -38,7 +38,7 @@ h1 {
 
 .subtitle {
   font-size: $font-size-base;
-  color: #6c757d;
+  color: $gray-dark;
   margin: 0;
 }
 
@@ -131,7 +131,7 @@ h1 {
 
 .login-link {
   font-size: $font-size-small;
-  color: #6c757d;
+  color: $gray-dark;
   margin: 0 0 16px 0;
 
   a {
@@ -149,7 +149,7 @@ h1 {
   display: inline-flex;
   align-items: center;
   gap: $spacing-xs;
-  color: #6c757d;
+  color: $gray-dark;
   text-decoration: none;
   font-size: $font-size-small;
   transition: color 0.2s;

--- a/frontend/src/app/features/exploration/exploration.component.scss
+++ b/frontend/src/app/features/exploration/exploration.component.scss
@@ -21,7 +21,7 @@
   gap: $spacing-xs;
   color: $primary-color;
   text-decoration: none;
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-small;
   font-weight: 600;
   transition: opacity 200ms ease-out;
@@ -40,7 +40,7 @@
 }
 
 .exploration-title {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: 32px;
   font-weight: 700;
   color: $primary-color;
@@ -56,7 +56,7 @@
 }
 
 .exploration-subtitle {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: 16px;
   font-weight: 400;
   color: $gray-dark;
@@ -78,7 +78,7 @@
 }
 
 .stats-title {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-h3;
   font-weight: 700;
   color: $primary-color;
@@ -86,7 +86,7 @@
 }
 
 .stats-subtitle {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-base;
   font-weight: 400;
   color: $gray-dark;
@@ -141,7 +141,7 @@
 }
 
 .stat-value {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-h1;
   font-weight: 700;
   color: $primary-color;
@@ -150,7 +150,7 @@
 }
 
 .stat-label {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-base;
   font-weight: 600;
   color: $gray-dark;
@@ -193,7 +193,7 @@
 }
 
 .coming-soon-title {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-h4;
   font-weight: 700;
   color: $primary-color;
@@ -201,7 +201,7 @@
 }
 
 .coming-soon-message {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-base;
   font-weight: 400;
   color: $gray-dark;

--- a/frontend/src/app/features/home/home.component.scss
+++ b/frontend/src/app/features/home/home.component.scss
@@ -26,7 +26,7 @@
 }
 
 .hero-title {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-h1;
   font-weight: 700;
   line-height: $line-height-h1;
@@ -35,7 +35,7 @@
 }
 
 .hero-subtitle {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-h3;
   font-weight: 400;
   line-height: $line-height-h3;
@@ -105,7 +105,7 @@ $bar-top-offset: 20px; // Plus d'espace au-dessus pour l'ellipse
 }
 
 .search-title {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-h4;
   font-weight: 700;
   line-height: $line-height-h4;
@@ -121,7 +121,7 @@ $bar-top-offset: 20px; // Plus d'espace au-dessus pour l'ellipse
 }
 
 .search-description {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-base;
   font-weight: 400;
   line-height: 22px;
@@ -198,7 +198,7 @@ $corner-size: 94px;
   min-height: 180px;
 
   .loading-text {
-    font-family: 'Nunito', sans-serif;
+    font-family: $font-family;
     font-size: $font-size-base;
     color: #949494;
     animation: pulse 1.5s ease-in-out infinite;
@@ -241,7 +241,7 @@ $corner-size: 94px;
   padding: 16px $spacing-lg;
   color: #025359;
   text-decoration: none;
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-base;
   font-weight: 600;
   transition: opacity 150ms ease-in-out;
@@ -288,7 +288,7 @@ $corner-size: 94px;
 }
 
 .guest-hero__title {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: 39px;
   font-weight: 700;
   line-height: $line-height-h1;
@@ -298,7 +298,7 @@ $corner-size: 94px;
 }
 
 .guest-hero__subtitle {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-h3;
   font-weight: 400;
   line-height: $line-height-h3;
@@ -316,7 +316,7 @@ $corner-size: 94px;
 }
 
 .guest-hero__btn {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-base;
   font-weight: 700;
   padding: $spacing-md $spacing-xl;
@@ -340,7 +340,7 @@ $corner-size: 94px;
 }
 
 .guest-hero__link {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-base;
   font-weight: 600;
   color: #025359;

--- a/frontend/src/app/features/home/home.component.scss
+++ b/frontend/src/app/features/home/home.component.scss
@@ -200,7 +200,7 @@ $corner-size: 94px;
   .loading-text {
     font-family: $font-family;
     font-size: $font-size-base;
-    color: #949494;
+    color: $gray-dark;
     animation: pulse 1.5s ease-in-out infinite;
   }
 }

--- a/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.html
+++ b/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.html
@@ -278,8 +278,8 @@
               <span class="section-label">{{ 'inventaires.form.sections.protocole' | translate }}</span>
             </div>
             <i class="fi section-chevron"
-              [class.fi-rr-angle-small-down]="sectionsOpen['protocole']"
-              [class.fi-rr-angle-small-right]="!sectionsOpen['protocole']"></i>
+              [class.fi-rr-angle-small-up]="sectionsOpen['protocole']"
+              [class.fi-rr-angle-small-down]="!sectionsOpen['protocole']"></i>
           </div>
           <div class="section-underline"></div>
 
@@ -559,8 +559,8 @@
               <span class="section-label">{{ 'inventaires.form.sections.bancarisation' | translate }}</span>
             </div>
             <i class="fi section-chevron"
-              [class.fi-rr-angle-small-down]="sectionsOpen['bancarisation']"
-              [class.fi-rr-angle-small-right]="!sectionsOpen['bancarisation']"></i>
+              [class.fi-rr-angle-small-up]="sectionsOpen['bancarisation']"
+              [class.fi-rr-angle-small-down]="!sectionsOpen['bancarisation']"></i>
           </div>
           <div class="section-underline"></div>
 
@@ -608,8 +608,8 @@
               <span class="section-label">{{ 'inventaires.form.sections.details' | translate }}</span>
             </div>
             <i class="fi section-chevron"
-              [class.fi-rr-angle-small-down]="sectionsOpen['details']"
-              [class.fi-rr-angle-small-right]="!sectionsOpen['details']"></i>
+              [class.fi-rr-angle-small-up]="sectionsOpen['details']"
+              [class.fi-rr-angle-small-down]="!sectionsOpen['details']"></i>
           </div>
           <div class="section-underline"></div>
 

--- a/frontend/src/app/features/my-requests/my-requests.component.scss
+++ b/frontend/src/app/features/my-requests/my-requests.component.scss
@@ -314,7 +314,7 @@
 }
 
 .pending-label {
-  color: #949494;
+  color: $gray-dark;
   font-style: italic;
 }
 

--- a/frontend/src/app/features/my-requests/my-requests.component.scss
+++ b/frontend/src/app/features/my-requests/my-requests.component.scss
@@ -10,9 +10,9 @@
   display: inline-flex;
   align-items: center;
   gap: $spacing-xs;
-  color: #025359;
+  color: $primary-color;
   text-decoration: none;
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-small;
   font-weight: 600;
   margin-bottom: $spacing-lg;
@@ -30,17 +30,17 @@
   margin-bottom: $spacing-xl;
 
   h1 {
-    font-family: 'Nunito', sans-serif;
+    font-family: $font-family;
     font-size: $font-size-h2;
     font-weight: 700;
-    color: #025359;
+    color: $primary-color;
     margin: 0 0 $spacing-xs;
   }
 
   .subtitle {
-    font-family: 'Nunito', sans-serif;
+    font-family: $font-family;
     font-size: $font-size-base;
-    color: #5C5C5C;
+    color: $gray-dark;
     margin: 0;
   }
 }
@@ -95,17 +95,17 @@
 }
 
 .stat-value {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: 25px;
   font-weight: 700;
-  color: #343433;
+  color: $black;
   line-height: 1.2;
 }
 
 .stat-label {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-small;
-  color: #5C5C5C;
+  color: $gray-dark;
 }
 
 /* Modules section */
@@ -117,22 +117,22 @@
   display: flex;
   align-items: center;
   gap: $spacing-sm;
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-h4;
   font-weight: 700;
-  color: #343433;
+  color: $black;
   margin: 0 0 $spacing-xs;
 }
 
 .section-icon {
   font-size: $font-size-h3;
-  color: #025359;
+  color: $primary-color;
 }
 
 .section-description {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-small;
-  color: #5C5C5C;
+  color: $gray-dark;
   margin: 0 0 $spacing-md;
 }
 
@@ -169,7 +169,7 @@
 
   i {
     font-size: $font-size-h3;
-    color: #025359;
+    color: $primary-color;
   }
 }
 
@@ -179,17 +179,17 @@
 }
 
 .module-name {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-base;
   font-weight: 700;
-  color: #343433;
+  color: $black;
   margin: 0 0 $spacing-xxs;
 }
 
 .module-description {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: 12px;
-  color: #5C5C5C;
+  color: $gray-dark;
   margin: 0;
   line-height: 1.4;
 }
@@ -235,22 +235,22 @@
 
 .empty-icon {
   font-size: 58px;
-  color: #DADADA;
+  color: $gray-dark;
   margin-bottom: $spacing-lg;
 }
 
 .empty-state h3 {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-h4;
   font-weight: 700;
-  color: #343433;
+  color: $black;
   margin: 0 0 $spacing-xs;
 }
 
 .empty-state p {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-base;
-  color: #5C5C5C;
+  color: $gray-dark;
   margin: 0 0 $spacing-lg;
   max-width: 360px;
 }
@@ -276,19 +276,19 @@
   width: 100%;
 
   th {
-    font-family: 'Nunito', sans-serif;
+    font-family: $font-family;
     font-size: 12px;
     font-weight: 700;
-    color: #5C5C5C;
+    color: $gray-dark;
     text-transform: uppercase;
     letter-spacing: 0.02em;
     background-color: #F8F5F1;
   }
 
   td {
-    font-family: 'Nunito', sans-serif;
+    font-family: $font-family;
     font-size: $font-size-small;
-    color: #343433;
+    color: $black;
   }
 }
 
@@ -304,13 +304,13 @@
 
   i {
     font-size: $font-size-small;
-    color: #025359;
+    color: $primary-color;
   }
 }
 
 .target-name {
   font-weight: 600;
-  color: #025359;
+  color: $primary-color;
 }
 
 .pending-label {

--- a/frontend/src/app/features/plans/enjeux/enjeu-accordion/enjeu-accordion.component.html
+++ b/frontend/src/app/features/plans/enjeux/enjeu-accordion/enjeu-accordion.component.html
@@ -34,7 +34,7 @@
         </button>
       }
       <button mat-icon-button class="expand-btn">
-        <i class="fi" [ngClass]="expanded() ? 'fi-rr-minus-circle' : 'fi-rr-add'"></i>
+        <i class="fi" [ngClass]="expanded() ? 'fi-rr-angle-up' : 'fi-rr-angle-down'"></i>
       </button>
     </div>
   </div>

--- a/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.html
+++ b/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.html
@@ -215,8 +215,7 @@
                       <i class="fi fi-rr-eye"></i>
                     </button>
                     <button class="icon-btn-flat icon-btn-flat--action" (click)="toggleEnjeuDetail(); $event.stopPropagation()">
-                      <i class="fi" [ngClass]="enjeuDetailExpanded() ? 'fi-rr-minus-circle' : 'fi-rr-add'"></i>
-
+                      <i class="fi" [ngClass]="enjeuDetailExpanded() ? 'fi-rr-angle-up' : 'fi-rr-angle-down'"></i>
                     </button>
                   </div>
                 </div>
@@ -404,7 +403,7 @@
                           </button>
                         }
                         <button class="icon-btn-flat icon-btn-flat--action" (click)="$event.stopPropagation(); toggleFacteur(facteur.id_facteur_influence)">
-                          <i class="fi" [ngClass]="isFacteurExpanded(facteur.id_facteur_influence) ? 'fi-rr-minus-circle' : 'fi-rr-add'"></i>
+                          <i class="fi" [ngClass]="isFacteurExpanded(facteur.id_facteur_influence) ? 'fi-rr-angle-up' : 'fi-rr-angle-down'"></i>
                         </button>
                       </div>
                     </div>
@@ -526,7 +525,7 @@
                                   </button>
                                 }
                                 <button class="icon-btn-flat icon-btn-flat--action" (click)="$event.stopPropagation(); togglePression(pression.id_pression)">
-                                  <i class="fi" [ngClass]="isPressionExpanded(pression.id_pression) ? 'fi-rr-minus-circle' : 'fi-rr-add'"></i>
+                                  <i class="fi" [ngClass]="isPressionExpanded(pression.id_pression) ? 'fi-rr-angle-up' : 'fi-rr-angle-down'"></i>
                                 </button>
                               </div>
                             </div>

--- a/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.scss
+++ b/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.scss
@@ -2081,7 +2081,7 @@
       color: $black;
 
       .mat-button-toggle-label-content {
-        font-family: 'Nunito', sans-serif;
+        font-family: $font-family;
         font-size: $font-size-small;
         font-weight: $font-weight-medium;
         line-height: 32px;
@@ -2117,7 +2117,7 @@
 // Optional bound checkbox — keep Material defaults intact for click behavior
 .optional-bound-checkbox {
   ::ng-deep .mdc-label {
-    font-family: 'Nunito', sans-serif;
+    font-family: $font-family;
     font-size: 11px;
     color: $gray-dark;
   }

--- a/frontend/src/app/features/plans/mindmap/plan-mindmap.component.scss
+++ b/frontend/src/app/features/plans/mindmap/plan-mindmap.component.scss
@@ -320,7 +320,7 @@
 :host ::ng-deep {
   .icicle-container svg {
     cursor: pointer;
-    font-family: 'Nunito', sans-serif;
+    font-family: $font-family;
 
     rect {
       transition: filter 0.15s;

--- a/frontend/src/app/features/plans/suivis/plan-suivi-actions.component.scss
+++ b/frontend/src/app/features/plans/suivis/plan-suivi-actions.component.scss
@@ -551,13 +551,13 @@ tr.is-draft {
   p {
     font-family: $font-family;
     font-size: $font-size-base;
-    color: $gray-dark;
+    color: $black;
     margin: 0;
   }
 
   .empty-hint {
     font-size: $font-size-small;
-    color: $gray;
+    color: $gray-dark;
     margin-top: $spacing-sm;
   }
 }

--- a/frontend/src/app/features/plans/suivis/plan-tableau-de-bord.component.scss
+++ b/frontend/src/app/features/plans/suivis/plan-tableau-de-bord.component.scss
@@ -573,13 +573,13 @@
   p {
     font-family: $font-family;
     font-size: $font-size-base;
-    color: $gray-dark;
+    color: $black;
     margin: 0;
   }
 
   .empty-hint {
     font-size: $font-size-small;
-    color: $gray;
+    color: $gray-dark;
     margin-top: $spacing-sm;
   }
 }

--- a/frontend/src/app/shared/components/modals/deactivate-user-modal/deactivate-user-modal.component.scss
+++ b/frontend/src/app/shared/components/modals/deactivate-user-modal/deactivate-user-modal.component.scss
@@ -55,7 +55,7 @@
 
 .user-email {
   font-size: $font-size-small;
-  color: #6c757d;
+  color: $gray-dark;
 }
 
 // Warning box

--- a/frontend/src/app/shared/components/modals/link-plan-referent-modal/link-plan-referent-modal.component.scss
+++ b/frontend/src/app/shared/components/modals/link-plan-referent-modal/link-plan-referent-modal.component.scss
@@ -81,7 +81,7 @@
   padding: $spacing-sm;
   background: white;
   border-radius: 5px;
-  color: #6c757d;
+  color: $gray-dark;
   font-size: 12px;
 
   i {
@@ -119,11 +119,11 @@
     .referent-item-info {
       .referent-name {
         text-decoration: line-through;
-        color: #6c757d;
+        color: $gray-dark;
       }
 
       i {
-        color: #6c757d;
+        color: $gray-dark;
       }
     }
   }
@@ -154,7 +154,7 @@
 
   .referent-email {
     font-size: 11px;
-    color: #6c757d;
+    color: $gray-dark;
     white-space: nowrap;
   }
 }
@@ -210,7 +210,7 @@
   padding: $spacing-xxs 9px;
   background: transparent;
   border: 1px solid #6c757d;
-  color: #6c757d;
+  color: $gray-dark;
   cursor: pointer;
   border-radius: $border-radius-sm;
   font-size: 11px;
@@ -318,7 +318,7 @@
 
   .option-email {
     font-size: 11px;
-    color: #6c757d;
+    color: $gray-dark;
   }
 }
 
@@ -356,7 +356,7 @@
   gap: $spacing-md;
 
   p {
-    color: #6c757d;
+    color: $gray-dark;
     margin: 0;
   }
 }

--- a/frontend/src/app/shared/components/modals/link-plan-site-modal/link-plan-site-modal.component.scss
+++ b/frontend/src/app/shared/components/modals/link-plan-site-modal/link-plan-site-modal.component.scss
@@ -81,7 +81,7 @@
   padding: $spacing-sm;
   background: white;
   border-radius: 5px;
-  color: #6c757d;
+  color: $gray-dark;
   font-size: 12px;
 
   i {
@@ -119,11 +119,11 @@
     .site-item-info {
       .site-name {
         text-decoration: line-through;
-        color: #6c757d;
+        color: $gray-dark;
       }
 
       i {
-        color: #6c757d;
+        color: $gray-dark;
       }
     }
   }
@@ -153,7 +153,7 @@
 
   .site-type {
     font-size: 11px;
-    color: #6c757d;
+    color: $gray-dark;
     white-space: nowrap;
   }
 }
@@ -209,7 +209,7 @@
   padding: $spacing-xxs 9px;
   background: transparent;
   border: 1px solid #6c757d;
-  color: #6c757d;
+  color: $gray-dark;
   cursor: pointer;
   border-radius: $border-radius-sm;
   font-size: 11px;
@@ -259,7 +259,7 @@
 
   .option-type {
     font-size: 11px;
-    color: #6c757d;
+    color: $gray-dark;
   }
 }
 
@@ -297,7 +297,7 @@
   gap: $spacing-md;
 
   p {
-    color: #6c757d;
+    color: $gray-dark;
     margin: 0;
   }
 }

--- a/frontend/src/app/shared/components/modals/link-site-organisme-modal/link-site-organisme-modal.component.scss
+++ b/frontend/src/app/shared/components/modals/link-site-organisme-modal/link-site-organisme-modal.component.scss
@@ -72,7 +72,7 @@
 .org-location,
 .site-type {
   font-size: $font-size-small;
-  color: #6c757d;
+  color: $gray-dark;
 }
 
 // Sites section
@@ -103,7 +103,7 @@
   padding: $spacing-sm;
   background: white;
   border-radius: 5px;
-  color: #6c757d;
+  color: $gray-dark;
   font-size: 12px;
 
   i {
@@ -146,11 +146,11 @@
     .site-item-info {
       .site-name {
         text-decoration: line-through;
-        color: #6c757d;
+        color: $gray-dark;
       }
 
       i {
-        color: #6c757d;
+        color: $gray-dark;
       }
     }
   }
@@ -232,13 +232,13 @@
 
     &.principal {
       background: #e9ecef;
-      color: #6c757d;
+      color: $gray-dark;
     }
   }
 
   .role-text {
     font-size: 11px;
-    color: #6c757d;
+    color: $gray-dark;
   }
 
   input[type="checkbox"]:checked + .role-label {
@@ -285,7 +285,7 @@
   padding: $spacing-xxs 9px;
   background: transparent;
   border: 1px solid #6c757d;
-  color: #6c757d;
+  color: $gray-dark;
   cursor: pointer;
   border-radius: $border-radius-sm;
   font-size: 11px;
@@ -329,7 +329,7 @@
 
   .roles-label {
     font-size: 12px;
-    color: #6c757d;
+    color: $gray-dark;
   }
 }
 
@@ -374,11 +374,11 @@
     .organisme-item-info {
       .organisme-name {
         text-decoration: line-through;
-        color: #6c757d;
+        color: $gray-dark;
       }
 
       i {
-        color: #6c757d;
+        color: $gray-dark;
       }
     }
   }
@@ -409,7 +409,7 @@
 
   .organisme-location {
     font-size: 11px;
-    color: #6c757d;
+    color: $gray-dark;
     white-space: nowrap;
   }
 }
@@ -446,7 +446,7 @@
 
   .roles-label {
     font-size: 12px;
-    color: #6c757d;
+    color: $gray-dark;
   }
 }
 
@@ -483,7 +483,7 @@
   .checkbox-description {
     display: block;
     font-size: 11px;
-    color: #6c757d;
+    color: $gray-dark;
     margin-top: 2px;
   }
 }
@@ -502,7 +502,7 @@
 
   .option-type {
     font-size: 11px;
-    color: #6c757d;
+    color: $gray-dark;
   }
 }
 
@@ -540,7 +540,7 @@
   gap: $spacing-md;
 
   p {
-    color: #6c757d;
+    color: $gray-dark;
     margin: 0;
   }
 }

--- a/frontend/src/app/shared/components/modals/link-user-organisme-modal/link-user-organisme-modal.component.scss
+++ b/frontend/src/app/shared/components/modals/link-user-organisme-modal/link-user-organisme-modal.component.scss
@@ -293,12 +293,12 @@
 
   .option-email {
     font-size: 11px;
-    color: #6c757d;
+    color: $gray-dark;
   }
 
   .option-org {
     font-size: 10px;
-    color: #FA9965;
+    color: $gray-dark;
     font-style: italic;
   }
 }

--- a/frontend/src/app/shared/components/modals/link-user-organisme-modal/link-user-organisme-modal.component.scss
+++ b/frontend/src/app/shared/components/modals/link-user-organisme-modal/link-user-organisme-modal.component.scss
@@ -73,7 +73,7 @@
 .user-email,
 .org-location {
   font-size: $font-size-small;
-  color: #6c757d;
+  color: $gray-dark;
 }
 
 // Users section
@@ -104,7 +104,7 @@
   padding: $spacing-sm;
   background: white;
   border-radius: 5px;
-  color: #6c757d;
+  color: $gray-dark;
   font-size: 12px;
 
   i {
@@ -143,7 +143,7 @@
       .user-name,
       .user-email {
         text-decoration: line-through;
-        color: #6c757d;
+        color: $gray-dark;
       }
     }
 
@@ -185,7 +185,7 @@
 
   .user-email {
     font-size: 11px;
-    color: #6c757d;
+    color: $gray-dark;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -243,7 +243,7 @@
   padding: $spacing-xxs 9px;
   background: transparent;
   border: 1px solid #6c757d;
-  color: #6c757d;
+  color: $gray-dark;
   cursor: pointer;
   border-radius: $border-radius-sm;
   font-size: 11px;
@@ -337,7 +337,7 @@
   gap: $spacing-md;
 
   p {
-    color: #6c757d;
+    color: $gray-dark;
     margin: 0;
   }
 }

--- a/frontend/src/app/shared/components/modals/link-user-site-modal/link-user-site-modal.component.scss
+++ b/frontend/src/app/shared/components/modals/link-user-site-modal/link-user-site-modal.component.scss
@@ -73,7 +73,7 @@
 .user-email,
 .site-type {
   font-size: $font-size-small;
-  color: #6c757d;
+  color: $gray-dark;
 }
 
 // Sites section
@@ -104,7 +104,7 @@
   padding: $spacing-sm;
   background: white;
   border-radius: 5px;
-  color: #6c757d;
+  color: $gray-dark;
   font-size: 12px;
 
   i {
@@ -147,11 +147,11 @@
     .site-item-info {
       .site-name {
         text-decoration: line-through;
-        color: #6c757d;
+        color: $gray-dark;
       }
 
       i {
-        color: #6c757d;
+        color: $gray-dark;
       }
     }
   }
@@ -233,13 +233,13 @@
 
     &.referent {
       background: #e9ecef;
-      color: #6c757d;
+      color: $gray-dark;
     }
   }
 
   .role-text {
     font-size: 11px;
-    color: #6c757d;
+    color: $gray-dark;
   }
 
   input[type="checkbox"]:checked + .role-label {
@@ -286,7 +286,7 @@
   padding: $spacing-xxs 9px;
   background: transparent;
   border: 1px solid #6c757d;
-  color: #6c757d;
+  color: $gray-dark;
   cursor: pointer;
   border-radius: $border-radius-sm;
   font-size: 11px;
@@ -330,7 +330,7 @@
 
   .roles-label {
     font-size: 12px;
-    color: #6c757d;
+    color: $gray-dark;
   }
 }
 
@@ -375,11 +375,11 @@
     .user-item-info {
       .user-name {
         text-decoration: line-through;
-        color: #6c757d;
+        color: $gray-dark;
       }
 
       i {
-        color: #6c757d;
+        color: $gray-dark;
       }
     }
   }
@@ -410,7 +410,7 @@
 
   .user-email-small {
     font-size: 11px;
-    color: #6c757d;
+    color: $gray-dark;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -449,7 +449,7 @@
 
   .roles-label {
     font-size: 12px;
-    color: #6c757d;
+    color: $gray-dark;
   }
 }
 
@@ -497,7 +497,7 @@
   .checkbox-description {
     display: block;
     font-size: 11px;
-    color: #6c757d;
+    color: $gray-dark;
     margin-top: 2px;
   }
 }
@@ -517,7 +517,7 @@
   .option-type,
   .option-email {
     font-size: 11px;
-    color: #6c757d;
+    color: $gray-dark;
   }
 }
 
@@ -555,7 +555,7 @@
   gap: $spacing-md;
 
   p {
-    color: #6c757d;
+    color: $gray-dark;
     margin: 0;
   }
 }

--- a/frontend/src/app/shared/components/modals/remove-user-organisme-modal/remove-user-organisme-modal.component.scss
+++ b/frontend/src/app/shared/components/modals/remove-user-organisme-modal/remove-user-organisme-modal.component.scss
@@ -55,7 +55,7 @@
 
 .user-email {
   font-size: $font-size-small;
-  color: #6c757d;
+  color: $gray-dark;
 }
 
 // Warning box

--- a/frontend/src/app/shared/components/module-access-request-dialog/module-access-request-dialog.component.ts
+++ b/frontend/src/app/shared/components/module-access-request-dialog/module-access-request-dialog.component.ts
@@ -93,7 +93,7 @@ export interface ModuleAccessRequestDialogData {
 
     .module-label {
       font-size: 12px;
-      color: #5C5C5C;
+      color: #746F6E;
       text-transform: uppercase;
       letter-spacing: 0.5px;
     }

--- a/frontend/src/app/shared/components/navigation-tile/navigation-tile.component.scss
+++ b/frontend/src/app/shared/components/navigation-tile/navigation-tile.component.scss
@@ -89,7 +89,7 @@ $card-border-radius-tr: 48px;
 }
 
 .tile-title {
-  font-family: 'Nunito', sans-serif;
+  font-family: $font-family;
   font-size: $font-size-h4;
   font-weight: 700;
   line-height: $line-height-h4;

--- a/frontend/src/app/shared/components/notification-bell/notification-bell.component.scss
+++ b/frontend/src/app/shared/components/notification-bell/notification-bell.component.scss
@@ -212,7 +212,7 @@
 .notification-item-message {
   display: block;
   font-size: $font-size-small;
-  color: $gray-dark;
+  color: $black;
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
@@ -224,7 +224,7 @@
 .notification-time {
   display: block;
   font-size: $font-size-small;
-  color: $gray;
+  color: $gray-dark;
   margin-top: 5px;
 }
 

--- a/frontend/src/app/shared/components/tag/tag.component.scss
+++ b/frontend/src/app/shared/components/tag/tag.component.scss
@@ -1,0 +1,127 @@
+@import 'variables';
+
+// Composant Tag unifié (issue #296)
+// Style pill, sans bordure, compact
+
+.app-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-xxs;
+  border-radius: $border-radius-pill;
+  font-family: $font-family;
+  font-weight: $font-weight-semibold;
+  line-height: 1.2;
+  white-space: nowrap;
+  border: none;
+  user-select: none;
+
+  // Taille md (par défaut)
+  &--md {
+    padding: 4px 12px;
+    font-size: $font-size-small;
+
+    i {
+      font-size: 12px;
+    }
+  }
+
+  // Taille sm (compacte, pour tableaux denses)
+  &--sm {
+    padding: 2px 8px;
+    font-size: 11px;
+
+    i {
+      font-size: 10px;
+    }
+  }
+
+  // ============================================
+  // VARIANTES SÉMANTIQUES (texte blanc sur fond)
+  // ============================================
+
+  &--success {
+    background-color: $success-color;
+    color: $white;
+  }
+
+  &--error {
+    background-color: $error-color;
+    color: $white;
+  }
+
+  &--info,
+  &--primary {
+    background-color: $primary-color;
+    color: $white;
+  }
+
+  // ============================================
+  // VARIANTES DÉCORATIVES (texte noir/primary sur pastel)
+  // ============================================
+
+  &--warning {
+    background-color: $secondary-orange-salmon;
+    color: $black;
+  }
+
+  &--draft {
+    background-color: $secondary-yellow;
+    color: $black;
+  }
+
+  &--neutral {
+    background-color: $secondary-pale-green;
+    color: $black;
+  }
+
+  &--muted {
+    background-color: $gray-light;
+    color: $black;
+  }
+
+  // ============================================
+  // SCORES (texte noir sur pastel, AA)
+  // ============================================
+
+  &--score-very-bad {
+    background-color: $score-very-bad;
+    color: $black;
+  }
+
+  &--score-bad {
+    background-color: $score-bad;
+    color: $black;
+  }
+
+  &--score-neutral {
+    background-color: $score-neutral;
+    color: $black;
+  }
+
+  &--score-good {
+    background-color: $score-good;
+    color: $black;
+  }
+
+  &--score-very-good {
+    background-color: $score-very-good;
+    color: $black;
+  }
+
+  // ============================================
+  // ÉTAT CLIQUABLE
+  // ============================================
+
+  &--clickable {
+    cursor: pointer;
+    transition: opacity 0.15s ease, transform 0.1s ease;
+
+    &:hover {
+      opacity: 0.85;
+    }
+
+    &:active {
+      transform: scale(0.97);
+    }
+  }
+}

--- a/frontend/src/app/shared/components/tag/tag.component.ts
+++ b/frontend/src/app/shared/components/tag/tag.component.ts
@@ -1,0 +1,71 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export type TagVariant =
+  // Statuts sémantiques (texte sur fond coloré, AA)
+  | 'success'      // Vert succès #04854B - blanc
+  | 'error'        // Rouge erreur #E12329 - blanc
+  | 'info'         // Bleu-vert principal #025359 - blanc
+  | 'primary'      // Bleu-vert principal (alias info)
+  // Statuts décoratifs (texte noir/primary sur fond pastel, AA)
+  | 'warning'      // Orange saumon #F5B399 - noir
+  | 'draft'        // Jaune #FEC180 - noir
+  | 'neutral'      // Vert pâle #C0E3CF - noir
+  | 'muted'        // Gris très clair #E4E4E4 - noir
+  // Scores
+  | 'score-very-bad'   // #FF7579 - noir
+  | 'score-bad'        // #FA9965 - noir
+  | 'score-neutral'    // #F7D35C - noir
+  | 'score-good'       // #82DB8A - noir
+  | 'score-very-good'; // #81C9D8 - noir
+
+export type TagSize = 'sm' | 'md';
+
+/**
+ * Tag - Composant de tag unifié (issue #296)
+ *
+ * Remplace les anciennes classes `.status-*`, `.score-*`, `.priority-*`, et les `mat-chip`.
+ * Style : pill, sans bordure, padding compact, pas de hover si non cliquable.
+ *
+ * @example Statut simple
+ * <app-tag variant="success" label="Validé"></app-tag>
+ *
+ * @example Avec icône
+ * <app-tag variant="warning" label="En attente" icon="fi-rr-clock"></app-tag>
+ *
+ * @example Cliquable (peut être édité)
+ * <app-tag variant="draft" label="Brouillon" [clickable]="true" (click)="onEdit()"></app-tag>
+ */
+@Component({
+  selector: 'app-tag',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <span
+      class="app-tag"
+      [class]="'app-tag--' + variant + ' app-tag--' + size"
+      [class.app-tag--clickable]="clickable">
+      @if (icon) {
+        <i class="fi" [class]="icon"></i>
+      }
+      <span class="app-tag__label">{{ label }}</span>
+    </span>
+  `,
+  styleUrl: './tag.component.scss',
+})
+export class TagComponent {
+  /** Variante de couleur du tag */
+  @Input() variant: TagVariant = 'neutral';
+
+  /** Texte affiché dans le tag */
+  @Input() label: string = '';
+
+  /** Icône Flaticon optionnelle (ex: 'fi-rr-check') */
+  @Input() icon?: string;
+
+  /** Taille du tag */
+  @Input() size: TagSize = 'md';
+
+  /** Si true, ajoute le curseur pointer et un effet hover léger */
+  @Input() clickable: boolean = false;
+}

--- a/frontend/src/app/shared/index.ts
+++ b/frontend/src/app/shared/index.ts
@@ -2,6 +2,7 @@
 export * from './components/header/header.component';
 export * from './components/navigation-tile/navigation-tile.component';
 export * from './components/ellipse-icon-button/ellipse-icon-button.component';
+export * from './components/tag/tag.component';
 
 // Icons
 export * from './components/icons/score-icon.component';

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -50,11 +50,16 @@
 // Error: Rouge (#E12329)
 
 // Use cyan palette as base (closest to our teal #025359)
+// Typography: Nunito everywhere — design review #294
 $theme: mat.define-theme((
   color: (
     theme-type: light,
     primary: mat.$cyan-palette,
     tertiary: mat.$orange-palette,
+  ),
+  typography: (
+    plain-family: 'Nunito, sans-serif',
+    brand-family: 'Nunito, sans-serif',
   ),
 ));
 


### PR DESCRIPTION
## Summary

Première PR de la revue design Amandine Laboulais 20/05/2026 (EPIC #293) — les **4 fondations transversales** qui débloquent toutes les autres issues du plan :

- **#294** Typo Nunito partout
- **#297** Harmonisation chevrons déplier/replier
- **#295** Règles de couleurs textes (accessibilité AA)
- **#296** Composant `<app-tag>` unifié

## Changes

### #294 Nunito ([Figma typo](https://www.figma.com/design/pfY82c4vXR0004CZ51jmVN?node-id=277-45746))

- **Cause racine corrigée** : ajout de `typography: (plain-family: 'Nunito', brand-family: 'Nunito')` au thème Material 3 dans `styles.scss`. Avant, Material appliquait Roboto par défaut sur ses composants (cf. menu déroulant header, inscription, modales, panneau Notifications…).
- Cleanup : 52 occurrences de `'Nunito', sans-serif` hardcodées remplacées par la variable `\$font-family` dans 10 fichiers SCSS (admin-settings, admin-update, login, register, exploration, home, my-requests, navigation-tile, mindmap, enjeux-list).

### #297 Chevrons ([règle](https://github.com/RNF-SI/Cicada/issues/297))

Règle : replié → chevron bas, déplié → chevron haut.

- 4 zones `fi-rr-add` / `fi-rr-minus-circle` → `fi-rr-angle-down` / `fi-rr-angle-up` :
  - `enjeu-accordion.component.html:37` (accordéon enjeux)
  - `enjeux-list.component.html:218` (détail enjeu)
  - `enjeux-list.component.html:407` (facteur d'influence)
  - `enjeux-list.component.html:529` (pression)
- 3 sections d'`inventaire-form.component.html` (protocole, bancarisation, details) : sens inversé corrigé (`angle-small-down` quand ouvert / `angle-small-right` quand fermé → `up` quand ouvert / `down` quand fermé).

### #295 Couleurs textes ([Figma couleurs AA](https://www.figma.com/design/pfY82c4vXR0004CZ51jmVN?node-id=277-44875))

- **notification-bell** : `.notification-time` `\$gray` (#C6C6C6) → `\$gray-dark`, `.notification-item-message` `\$gray-dark` → `\$black` (cf. retour Amandine).
- **my-requests** : tous les `#5C5C5C` (gris hors charte) et `#DADADA` (gris quasi blanc) → variables `\$gray-dark` ou `\$black` selon contexte. Aussi `#025359` / `#343433` → `\$primary-color` / `\$black` pour cohérence.
- **link-user-organisme-modal** : `.option-org` `#FA9965` (saumon, interdit en texte) → `\$gray-dark`.
- **Empty states** `plan-suivi-actions` + `plan-tableau-de-bord` : titre `<p>` `\$gray-dark` → `\$black`, `.empty-hint` `\$gray` → `\$gray-dark`.

### #296 Composant `<app-tag>` ([Figma tableaux](https://www.figma.com/design/pfY82c4vXR0004CZ51jmVN?node-id=281-52360))

Composant Angular standalone créé : `frontend/src/app/shared/components/tag/tag.component.{ts,scss}`.

- **14 variantes** :
  - Sémantiques (texte blanc, AA) : `success`, `error`, `info` / `primary`
  - Décoratives (texte noir, AA) : `warning` (saumon), `draft` (jaune), `neutral` (vert pâle), `muted` (gris clair)
  - Scores (texte noir, AA) : `score-very-bad`, `score-bad`, `score-neutral`, `score-good`, `score-very-good`
- Style pill (`\$border-radius-pill`), **sans bordure**, padding compact, icône optionnelle à gauche.
- Tailles `sm` (tableaux denses) et `md` (défaut).
- Pas de hover/curseur si non cliquable.
- Documenté dans `CLAUDE.md`.

> ⚠️ **Migration des ~109 usages existants** (mat-chip + spans `.status-*`, `.score-*`, `.priority-*`) **non incluse** dans cette PR pour limiter la taille — sera faite progressivement dans les PRs C de l'EPIC (par section app). Le composant est prêt à être utilisé.

## Test plan

- [x] Tests unitaires Jest : 55 suites / 1655 tests passent
- [x] Build Angular : `Application bundle generation complete. [2.343 seconds]`, pas d'erreur
- [ ] Vérification visuelle manuelle :
  - [ ] Profil, dropdown header, inscription, modale création/recherche site, panneau notifications, mes demandes → Nunito appliquée partout (pas de Roboto)
  - [ ] Liste enjeux : chevrons haut/bas (plus de `+`/`-`)
  - [ ] Détail facteur d'influence > pression : chevrons cohérents
  - [ ] Inventaire form : sections protocole / bancarisation / details — chevron pointe vers le haut quand bloc déplié
  - [ ] Panneau notifications : date plus lisible (gris foncé), message en noir
  - [ ] Page Mes demandes : textes en noir lisibles
  - [ ] Modale "Lier utilisateur à organisme" : option organisme plus en saumon
  - [ ] Page Suivi des actions (état vide) : "Aucun indicateur..." en noir, hint en gris foncé
  - [ ] Composant `<app-tag>` : si testable avec une mini-page de démo

## Issues couvertes

Cette PR ferme les 4 issues fondations de l'EPIC #293 :
- Closes #294
- Closes #295
- Closes #296
- Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)