### PR TITLE
feat(design): phase B - 7 composants kit UI (search, checkbox, form-field, stepper, tile, accordion, anchor-nav)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,192 @@ Les composants standalone sont dans `frontend/src/app/shared/components/`.
 <app-header></app-header>
 ```
 
+### Kit UI Components (issues #298-#304)
+
+Composants issus de la revue design 05/2026, à utiliser à la place des composants Material équivalents pour respecter le kit UI.
+
+#### `SearchBarComponent` (#298)
+**Sélecteur**: `app-search-bar` — **Fichiers**: `search-bar/`
+
+Barre de recherche unifiée avec 2 variantes. Texte d'aide AVANT le champ (accessibilité).
+
+```html
+<!-- Auto-filtre (défaut) -->
+<app-search-bar [(value)]="query" placeholder="Rechercher un site..."></app-search-bar>
+
+<!-- Manuel avec bouton -->
+<app-search-bar
+  mode="manual"
+  helpText="Entrez au moins 2 caractères"
+  placeholder="Rechercher un plan..."
+  (search)="onSearch($event)">
+</app-search-bar>
+```
+
+| Input | Type | Défaut | Description |
+|-------|------|--------|-------------|
+| `mode` | `'auto' \| 'manual'` | `'auto'` | `auto` filtre instantané, `manual` avec bouton |
+| `value` | `string` | `''` | Two-way binding |
+| `placeholder` | `string` | `''` | Placeholder du champ |
+| `helpText` | `string?` | — | Texte d'aide AVANT le champ |
+| `ariaLabel` | `string` | `'Rechercher'` | Label lecteur d'écran |
+| `disabled` | `boolean` | `false` | — |
+
+Outputs : `valueChange`, `search` (manuel), `cleared`.
+
+#### `CheckboxComponent` (#299)
+**Sélecteur**: `app-checkbox` — **Fichiers**: `checkbox/`
+
+Checkbox custom (carré arrondi, **sans cercle Material**). Compatible Reactive Forms.
+
+```html
+<app-checkbox [(checked)]="agreed" label="J'accepte"></app-checkbox>
+<app-checkbox [(checked)]="copy" label="Sites associés" mention="Copie les associations site-plan"></app-checkbox>
+<app-checkbox formControlName="active" label="Site actif"></app-checkbox>
+```
+
+| Input | Type | Défaut | Description |
+|-------|------|--------|-------------|
+| `checked` | `boolean` | `false` | Two-way binding |
+| `label` | `string` | `''` | Label principal |
+| `mention` | `string?` | — | Texte mention sous le label |
+| `disabled` | `boolean` | `false` | — |
+
+#### `FormFieldComponent` (#300)
+**Sélecteur**: `app-form-field` — **Fichiers**: `form-field/`
+
+Wrapper pour champs compacts : label **au-dessus** du champ, asterisque rouge si requis, état erreur. Plus dense que Material.
+
+```html
+<app-form-field label="Nom du site" required>
+  <input type="text" formControlName="name" />
+</app-form-field>
+
+<app-form-field
+  label="Surface (ha)"
+  helpText="Saisissez un nombre entier"
+  suffix="ha"
+  [error]="form.controls.surface.touched && form.controls.surface.errors?.['min'] ? 'La surface doit être ≥ 0' : null">
+  <input type="number" formControlName="surface" />
+</app-form-field>
+```
+
+| Input | Type | Défaut | Description |
+|-------|------|--------|-------------|
+| `label` | `string` | `''` | Label au-dessus du champ |
+| `required` | `boolean` | `false` | Ajoute astérisque rouge |
+| `helpText` | `string?` | — | Aide ENTRE label et champ |
+| `error` | `string \| null` | — | Message d'erreur (active l'état erreur) |
+| `suffix` | `string?` | — | Suffixe (ex: 'ha', '€') |
+
+Le `<input>`/`<select>`/`<textarea>` est projeté dans le composant — utiliser `formControlName` ou `ngModel` directement sur l'élément projeté.
+
+#### `StepperComponent` (#301)
+**Sélecteur**: `app-stepper` — **Fichiers**: `stepper/`
+
+Stepper pour processus multi-étapes (import en masse, etc.).
+
+```html
+<app-stepper
+  [steps]="[
+    { id: 1, label: 'Fichier', completed: true },
+    { id: 2, label: 'Correspondance', completed: true },
+    { id: 3, label: 'Vérification' },
+    { id: 4, label: 'Résultats' }
+  ]"
+  [currentStep]="3"
+  (stepClick)="goToStep($event)">
+</app-stepper>
+```
+
+| Input | Type | Défaut | Description |
+|-------|------|--------|-------------|
+| `steps` | `StepperStep[]` | `[]` | `{ id, label, completed? }` |
+| `currentStep` | `string \| number` | `1` | Étape active (ID ou index 1-based) |
+| `allowGoBack` | `boolean` | `true` | Étapes complétées cliquables |
+
+#### `EntityTileComponent` (#302)
+**Sélecteur**: `app-entity-tile` — **Fichiers**: `entity-tile/`
+
+Tuile compacte pour site / utilisateur / organisme (vue d'ensemble plan, modales).
+
+```html
+<app-entity-tile
+  icon="fi-rr-marker"
+  name="Réserve Naturelle du Lac de Remoray"
+  subtitle="Réserves Naturelles de France">
+  <button tileAction class="link-default">Demander l'accès</button>
+</app-entity-tile>
+
+<app-entity-tile icon="fi-rr-user" name="Marie Dupont" subtitle="marie@test.fr" [clickable]="true" (tileClick)="open()">
+  <app-tag tileAction variant="warning" label="Référent" />
+</app-entity-tile>
+```
+
+| Input | Type | Défaut | Description |
+|-------|------|--------|-------------|
+| `icon` | `string` | `'fi-rr-document'` | Classe Flaticon |
+| `name` | `string` | `''` | Nom principal (bold) |
+| `subtitle` | `string?` | — | Sous-info (gris foncé) |
+| `clickable` | `boolean` | `false` | Active hover + cursor + tileClick |
+
+Action à droite via `<element tileAction>` (slot).
+
+#### `AccordionComponent` (#303)
+**Sélecteur**: `app-accordion` — **Fichiers**: `accordion/`
+
+Accordéon générique avec chevron haut/bas conforme #297. 4 variantes (default, enjeu, fcr, subtle), 3 tailles (sm, md, lg).
+
+```html
+<app-accordion title="Détails du protocole">
+  <p>Contenu déplié...</p>
+</app-accordion>
+
+<app-accordion variant="enjeu" title="Enjeu 3 : Préservation" [(expanded)]="isOpen">
+  <i accordionIcon class="fi fi-rr-mountains"></i>
+  <button accordionActions class="icon-btn-flat" (click)="onEdit($event)">
+    <i class="fi fi-rr-pencil"></i>
+  </button>
+  <p>Détails…</p>
+</app-accordion>
+```
+
+| Input | Type | Défaut | Description |
+|-------|------|--------|-------------|
+| `title` | `string` | `''` | Titre header |
+| `variant` | `'default' \| 'enjeu' \| 'fcr' \| 'subtle'` | `'default'` | Style visuel |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Espacement |
+| `expanded` | `boolean` | `false` | État (two-way binding via expandedChange) |
+| `disabled` | `boolean` | `false` | — |
+
+Slots : `[accordionIcon]` (icône à gauche du titre), `[accordionActions]` (boutons à droite, à côté du chevron), corps par défaut.
+
+#### `AnchorNavComponent` (#304)
+**Sélecteur**: `app-anchor-nav` — **Fichiers**: `anchor-nav/`
+
+Navigation interne par ancres : boutons tertiaires bleu-vert séparés par `/`. Scroll smooth automatique vers la section.
+
+```html
+<app-anchor-nav
+  [items]="[
+    { id: 'overview', label: 'Vue d\'ensemble' },
+    { id: 'info', label: 'Informations' },
+    { id: 'organismes', label: 'Organismes' },
+    { id: 'users', label: 'Utilisateurs' },
+    { id: 'plans', label: 'Plans de gestion' }
+  ]"
+  [activeId]="currentSection">
+</app-anchor-nav>
+```
+
+| Input | Type | Défaut | Description |
+|-------|------|--------|-------------|
+| `items` | `AnchorNavItem[]` | `[]` | `{ id, label, icon? }` |
+| `activeId` | `string?` | — | ID de l'item actif (mise en évidence) |
+| `scrollOnClick` | `boolean` | `true` | Scroll smooth automatique vers `#id` |
+
+Les sections cibles doivent avoir un `id` correspondant (ex: `<section id="overview">...`).
+
 ## Common Development Commands
 
 ### Project Setup (Current Implementation)

--- a/frontend/src/app/features/activity/activity.component.html
+++ b/frontend/src/app/features/activity/activity.component.html
@@ -40,8 +40,9 @@
         (search)="applyFilters()">
       </app-search-bar>
 
-      <mat-form-field appearance="outline" class="filter-field">
-        <mat-label>{{ 'activity.filters.entityType' | translate }}</mat-label>
+      <label class="app-mat-label">{{ 'activity.filters.entityType' | translate }}</label>
+      <mat-form-field class="app-mat-form-field filter-field" appearance="outline">>
+        <mat-label></mat-label>
         <mat-select [(ngModel)]="entityTypeFilter" (selectionChange)="applyFilters()">
           <mat-option value="">{{ 'common.all' | translate }}</mat-option>
           <mat-option value="site">{{ 'activity.entityTypes.site' | translate }}</mat-option>

--- a/frontend/src/app/features/activity/activity.component.html
+++ b/frontend/src/app/features/activity/activity.component.html
@@ -31,11 +31,14 @@
 
   <!-- Filters -->
   <div class="filters-bar">
-      <mat-form-field appearance="outline" class="search-field">
-        <mat-label>{{ 'common.actions.search' | translate }}</mat-label>
-        <input matInput [(ngModel)]="searchQuery" (keyup.enter)="applyFilters()">
-        <i class="fi-rr-search" matSuffix></i>
-      </mat-form-field>
+      <app-search-bar
+        class="search-field"
+        mode="manual"
+        [(value)]="searchQuery"
+        [placeholder]="'common.actions.search' | translate"
+        [ariaLabel]="'common.actions.search' | translate"
+        (search)="applyFilters()">
+      </app-search-bar>
 
       <mat-form-field appearance="outline" class="filter-field">
         <mat-label>{{ 'activity.filters.entityType' | translate }}</mat-label>

--- a/frontend/src/app/features/activity/activity.component.ts
+++ b/frontend/src/app/features/activity/activity.component.ts
@@ -21,6 +21,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 import { ActivityService } from '../../core/services/activity.service';
 import { AuthService } from '../../core/services/auth.service';
+import { SearchBarComponent } from '../../shared/components/search-bar/search-bar.component';
 import {
   ActivityLogListItem,
   ActivityFilters,
@@ -48,7 +49,8 @@ import {
     MatPaginatorModule,
     MatTooltipModule,
     MatExpansionModule,
-    TranslateModule
+    TranslateModule,
+    SearchBarComponent,
   ],
   templateUrl: './activity.component.html',
   styleUrl: './activity.component.scss'

--- a/frontend/src/app/features/admin/admin-logs/admin-logs.component.html
+++ b/frontend/src/app/features/admin/admin-logs/admin-logs.component.html
@@ -20,8 +20,9 @@
 
   <!-- Filtres -->
   <div class="filters-bar">
-    <mat-form-field appearance="outline" class="filter-field">
-      <mat-label>{{ 'admin.logs.filters.level' | translate }}</mat-label>
+    <label class="app-mat-label">{{ 'admin.logs.filters.level' | translate }}</label>
+      <mat-form-field class="app-mat-form-field filter-field" appearance="outline">>
+      <mat-label></mat-label>
       <mat-select [(ngModel)]="levelFilter" (selectionChange)="applyFilters()">
         @for (option of levelOptions; track option.value) {
           <mat-option [value]="option.value">{{ option.label }}</mat-option>
@@ -29,8 +30,9 @@
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field appearance="outline" class="filter-field">
-      <mat-label>{{ 'admin.logs.filters.acknowledged' | translate }}</mat-label>
+    <label class="app-mat-label">{{ 'admin.logs.filters.acknowledged' | translate }}</label>
+      <mat-form-field class="app-mat-form-field filter-field" appearance="outline">>
+      <mat-label></mat-label>
       <mat-select [(ngModel)]="acknowledgedFilter" (selectionChange)="applyFilters()">
         @for (option of acknowledgedOptions; track option.value) {
           <mat-option [value]="option.value">{{ option.label }}</mat-option>

--- a/frontend/src/app/features/admin/admin-logs/admin-logs.component.html
+++ b/frontend/src/app/features/admin/admin-logs/admin-logs.component.html
@@ -38,20 +38,18 @@
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field appearance="outline" class="filter-field search-field">
-      <mat-label>{{ 'admin.logs.filters.search' | translate }}</mat-label>
+    <app-form-field class="filter-field search-field" [label]="'admin.logs.filters.search' | translate">
       <input
-        matInput
         [(ngModel)]="searchFilter"
         (keyup.enter)="applyFilters()"
         [placeholder]="'admin.logs.filters.searchPlaceholder' | translate"
       >
       @if (searchFilter) {
-        <button matSuffix mat-icon-button (click)="searchFilter = ''; applyFilters()">
+        <button suffixSlot (click)="searchFilter = ''; applyFilters()">
           <i class="fi fi-rr-cross-small"></i>
         </button>
       }
-    </mat-form-field>
+    </app-form-field>
 
     <button mat-icon-button (click)="applyFilters()" [matTooltip]="'common.actions.search' | translate">
       <i class="fi fi-rr-search"></i>

--- a/frontend/src/app/features/admin/admin-logs/admin-logs.component.ts
+++ b/frontend/src/app/features/admin/admin-logs/admin-logs.component.ts
@@ -12,6 +12,7 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatSelectModule } from '@angular/material/select';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { FormFieldComponent } from '../../../shared/components/form-field/form-field.component';
 import { MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
@@ -42,6 +43,7 @@ import { ErrorLogDetailDialogComponent } from './error-log-detail-dialog.compone
     MatSelectModule,
     MatFormFieldModule,
     MatInputModule,
+    FormFieldComponent,
     MatDialogModule,
     MatSnackBarModule,
     MatProgressSpinnerModule,

--- a/frontend/src/app/features/admin/admin-organismes.component.html
+++ b/frontend/src/app/features/admin/admin-organismes.component.html
@@ -22,15 +22,13 @@
   <!-- Search (Super Admin only) -->
   @if (isSuperAdmin()) {
     <div class="filters-bar">
-      <div class="search-box">
-        <i class="fi fi-rr-search"></i>
-        <input
-          type="text"
-          [placeholder]="'admin.organismes.search' | translate"
-          [(ngModel)]="searchQuery"
-          (ngModelChange)="onSearchChange()"
-        />
-      </div>
+      <app-search-bar
+        class="filters-search"
+        [(value)]="searchQuery"
+        [placeholder]="'admin.organismes.search' | translate"
+        [ariaLabel]="'admin.organismes.search' | translate"
+        (valueChange)="onSearchChange()">
+      </app-search-bar>
     </div>
   }
 

--- a/frontend/src/app/features/admin/admin-organismes.component.ts
+++ b/frontend/src/app/features/admin/admin-organismes.component.ts
@@ -12,6 +12,7 @@ import { AuthService } from '../../core/services/auth.service';
 import { AdminService } from '../../core/services/admin.service';
 import { AdminOrganisme } from '../../core/models/admin.model';
 import { PaginationComponent } from '../../shared/components/pagination/pagination.component';
+import { SearchBarComponent } from '../../shared/components/search-bar/search-bar.component';
 import {
   OrganismeFormModalComponent,
   LinkUserOrganismeModalComponent,
@@ -47,7 +48,8 @@ interface DisplayOrganisme {
     MatProgressSpinnerModule,
     MatTooltipModule,
     TranslateModule,
-    PaginationComponent
+    PaginationComponent,
+    SearchBarComponent,
   ],
   templateUrl: './admin-organismes.component.html',
   styleUrl: './admin-organismes.component.scss'

--- a/frontend/src/app/features/admin/admin-plans.component.html
+++ b/frontend/src/app/features/admin/admin-plans.component.html
@@ -57,15 +57,13 @@
 
   <!-- Filters -->
   <div class="filters-bar">
-    <div class="search-box">
-      <i class="fi fi-rr-search"></i>
-      <input
-        type="text"
-        [placeholder]="'admin.plans.search' | translate"
-        [(ngModel)]="searchQuery"
-        (ngModelChange)="onSearchChange()"
-      />
-    </div>
+    <app-search-bar
+      class="filters-search"
+      [(value)]="searchQuery"
+      [placeholder]="'admin.plans.search' | translate"
+      [ariaLabel]="'admin.plans.search' | translate"
+      (valueChange)="onSearchChange()">
+    </app-search-bar>
 
     <div class="filters">
       <select [(ngModel)]="filterStatut" (ngModelChange)="onFilterChange()">

--- a/frontend/src/app/features/admin/admin-plans.component.ts
+++ b/frontend/src/app/features/admin/admin-plans.component.ts
@@ -17,6 +17,7 @@ import { LinkPlanSiteModalComponent } from '../../shared/components/modals/link-
 import { LinkPlanReferentModalComponent } from '../../shared/components/modals/link-plan-referent-modal/link-plan-referent-modal.component';
 import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog/confirm-dialog.component';
 import { PaginationComponent } from '../../shared/components/pagination/pagination.component';
+import { SearchBarComponent } from '../../shared/components/search-bar/search-bar.component';
 
 // Interface for linked site display
 interface DisplaySiteLie {
@@ -90,7 +91,8 @@ interface DisplayOrganisme {
     MatProgressSpinnerModule,
     MatTooltipModule,
     TranslateModule,
-    PaginationComponent
+    PaginationComponent,
+    SearchBarComponent,
   ],
   templateUrl: './admin-plans.component.html',
   styleUrl: './admin-plans.component.scss'

--- a/frontend/src/app/features/admin/admin-redacteurs-principaux.component.html
+++ b/frontend/src/app/features/admin/admin-redacteurs-principaux.component.html
@@ -64,15 +64,12 @@
           </button>
         </div>
         <div class="dialog-body">
-          <div class="search-box">
-            <i class="fi fi-rr-search"></i>
-            <input
-              type="text"
-              [placeholder]="'admin.users.search' | translate"
-              [ngModel]="searchQuery()"
-              (ngModelChange)="searchQuery.set($event); onSearch()"
-            />
-          </div>
+          <app-search-bar
+            [value]="searchQuery()"
+            [placeholder]="'admin.users.search' | translate"
+            [ariaLabel]="'admin.users.search' | translate"
+            (valueChange)="searchQuery.set($event); onSearch()">
+          </app-search-bar>
 
           @if (isSearching()) {
             <div class="search-loading">

--- a/frontend/src/app/features/admin/admin-redacteurs-principaux.component.ts
+++ b/frontend/src/app/features/admin/admin-redacteurs-principaux.component.ts
@@ -7,6 +7,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 import { AdminService } from '../../core/services/admin.service';
 import { AuthService } from '../../core/services/auth.service';
+import { SearchBarComponent } from '../../shared/components/search-bar/search-bar.component';
 
 interface RedacteurPrincipal {
   id: number;
@@ -29,7 +30,7 @@ interface SearchUser {
   selector: 'app-admin-redacteurs-principaux',
   standalone: true,
   imports: [
-    CommonModule, FormsModule, MatProgressSpinnerModule, MatSnackBarModule, TranslateModule
+    CommonModule, FormsModule, MatProgressSpinnerModule, MatSnackBarModule, TranslateModule, SearchBarComponent,
   ],
   templateUrl: './admin-redacteurs-principaux.component.html',
   styleUrls: ['./admin-redacteurs-principaux.component.scss']

--- a/frontend/src/app/features/admin/admin-sites.component.html
+++ b/frontend/src/app/features/admin/admin-sites.component.html
@@ -23,15 +23,13 @@
 
   <!-- Filters -->
   <div class="filters-bar">
-    <div class="search-box">
-      <i class="fi fi-rr-search"></i>
-      <input
-        type="text"
-        [placeholder]="'admin.sites.search' | translate"
-        [(ngModel)]="searchQuery"
-        (ngModelChange)="onSearchChange()"
-      />
-    </div>
+    <app-search-bar
+      class="filters-search"
+      [(value)]="searchQuery"
+      [placeholder]="'admin.sites.search' | translate"
+      [ariaLabel]="'admin.sites.search' | translate"
+      (valueChange)="onSearchChange()">
+    </app-search-bar>
 
     <div class="filters">
       <select [(ngModel)]="filterType" (ngModelChange)="onFilterChange()">

--- a/frontend/src/app/features/admin/admin-sites.component.ts
+++ b/frontend/src/app/features/admin/admin-sites.component.ts
@@ -12,6 +12,7 @@ import { AuthService } from '../../core/services/auth.service';
 import { AdminService } from '../../core/services/admin.service';
 import { AdminSite as ApiSite, AdminOrganisme } from '../../core/models/admin.model';
 import { PaginationComponent } from '../../shared/components/pagination/pagination.component';
+import { SearchBarComponent } from '../../shared/components/search-bar/search-bar.component';
 import {
   LinkUserSiteModalComponent,
   LinkSiteOrganismeModalComponent,
@@ -66,7 +67,8 @@ interface DisplayOrganisme {
     MatProgressSpinnerModule,
     MatTooltipModule,
     TranslateModule,
-    PaginationComponent
+    PaginationComponent,
+    SearchBarComponent,
   ],
   templateUrl: './admin-sites.component.html',
   styleUrl: './admin-sites.component.scss'

--- a/frontend/src/app/features/admin/admin-users.component.html
+++ b/frontend/src/app/features/admin/admin-users.component.html
@@ -16,15 +16,13 @@
 
   <!-- Filters -->
   <div class="filters-bar">
-    <div class="search-box">
-      <i class="fi fi-rr-search"></i>
-      <input
-        type="text"
-        [placeholder]="'admin.users.search' | translate"
-        [(ngModel)]="searchQuery"
-        (ngModelChange)="onSearchChange()"
-      />
-    </div>
+    <app-search-bar
+      class="filters-search"
+      [(value)]="searchQuery"
+      [placeholder]="'admin.users.search' | translate"
+      [ariaLabel]="'admin.users.search' | translate"
+      (valueChange)="onSearchChange()">
+    </app-search-bar>
 
     <div class="filters">
       <select [(ngModel)]="filterRole" (ngModelChange)="onFilterChange()">

--- a/frontend/src/app/features/admin/admin-users.component.ts
+++ b/frontend/src/app/features/admin/admin-users.component.ts
@@ -14,6 +14,7 @@ import { AdminService } from '../../core/services/admin.service';
 import { AdminUser as ApiUser, AdminOrganisme, UserSiteRelation } from '../../core/models/admin.model';
 import { UserRole } from '../../core/models/user.model';
 import { PaginationComponent } from '../../shared/components/pagination/pagination.component';
+import { SearchBarComponent } from '../../shared/components/search-bar/search-bar.component';
 import {
   LinkUserOrganismeModalComponent,
   LinkUserSiteModalComponent,
@@ -77,7 +78,8 @@ interface DisplayOrganisme {
     MatProgressSpinnerModule,
     MatTooltipModule,
     TranslateModule,
-    PaginationComponent
+    PaginationComponent,
+    SearchBarComponent,
   ],
   templateUrl: './admin-users.component.html',
   styleUrl: './admin-users.component.scss'

--- a/frontend/src/app/features/admin/admin-validations/admin-validations.component.html
+++ b/frontend/src/app/features/admin/admin-validations/admin-validations.component.html
@@ -6,8 +6,9 @@
 
   <!-- Filtres -->
   <div class="filters-bar">
-    <mat-form-field appearance="outline" class="filter-field">
-      <mat-label>Statut</mat-label>
+    <label class="app-mat-label">Statut</label>
+      <mat-form-field class="app-mat-form-field filter-field" appearance="outline">>
+      <mat-label></mat-label>
       <mat-select [(ngModel)]="statusFilter" (selectionChange)="applyFilters()">
         @for (option of statusOptions(); track option.value) {
           <mat-option [value]="option.value">{{ option.label }}</mat-option>
@@ -15,8 +16,9 @@
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field appearance="outline" class="filter-field">
-      <mat-label>Type de demande</mat-label>
+    <label class="app-mat-label">Type de demande</label>
+      <mat-form-field class="app-mat-form-field filter-field" appearance="outline">>
+      <mat-label></mat-label>
       <mat-select [(ngModel)]="typeFilter" (selectionChange)="applyFilters()">
         @for (option of typeOptions(); track option.value) {
           <mat-option [value]="option.value">{{ option.label }}</mat-option>

--- a/frontend/src/app/features/auth/login.component.html
+++ b/frontend/src/app/features/auth/login.component.html
@@ -14,48 +14,43 @@
         </div>
       }
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'auth.login.username' | translate }}</mat-label>
+      <app-form-field class="full-width" [label]="'auth.login.username' | translate">
+        <i prefixSlot class="fi fi-rr-user field-icon"></i>
         <input
-          matInput
           type="text"
           formControlName="username"
           [placeholder]="'auth.login.usernamePlaceholder' | translate"
           autocomplete="username"
         >
-        <mat-icon matPrefix class="field-icon">
-          <i class="fi fi-rr-user"></i>
-        </mat-icon>
-        @if (loginForm.get('username')?.hasError('required') && loginForm.get('username')?.touched) {
-          <mat-error>{{ 'auth.login.errors.usernameRequired' | translate }}</mat-error>
-        }
-      </mat-form-field>
+        <ng-container errorSlot>
+          @if (loginForm.get('username')?.hasError('required') && loginForm.get('username')?.touched) {
+            <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'auth.login.errors.usernameRequired' | translate }}</p>
+          }
+        </ng-container>
+      </app-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'auth.login.password' | translate }}</mat-label>
+      <app-form-field class="full-width" [label]="'auth.login.password' | translate">
+        <i prefixSlot class="fi fi-rr-lock field-icon"></i>
         <input
-          matInput
           [type]="hidePassword() ? 'password' : 'text'"
           formControlName="password"
           [placeholder]="'auth.login.passwordPlaceholder' | translate"
           autocomplete="current-password"
         >
-        <mat-icon matPrefix class="field-icon">
-          <i class="fi fi-rr-lock"></i>
-        </mat-icon>
         <button
-          mat-icon-button
-          matSuffix
+          suffixSlot
           type="button"
           (click)="togglePasswordVisibility()"
           [attr.aria-label]="(hidePassword() ? 'auth.login.showPassword' : 'auth.login.hidePassword') | translate"
         >
           <i class="fi" [class.fi-rr-eye]="hidePassword()" [class.fi-rr-eye-crossed]="!hidePassword()"></i>
         </button>
-        @if (loginForm.get('password')?.hasError('required') && loginForm.get('password')?.touched) {
-          <mat-error>{{ 'auth.login.errors.passwordRequired' | translate }}</mat-error>
-        }
-      </mat-form-field>
+        <ng-container errorSlot>
+          @if (loginForm.get('password')?.hasError('required') && loginForm.get('password')?.touched) {
+            <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'auth.login.errors.passwordRequired' | translate }}</p>
+          }
+        </ng-container>
+      </app-form-field>
 
       <button
         mat-flat-button

--- a/frontend/src/app/features/auth/login.component.ts
+++ b/frontend/src/app/features/auth/login.component.ts
@@ -2,13 +2,11 @@ import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslateModule } from '@ngx-translate/core';
 import { AuthService } from '../../core/services/auth.service';
+import { FormFieldComponent } from '../../shared/components/form-field/form-field.component';
 
 @Component({
   selector: 'app-login',
@@ -17,12 +15,10 @@ import { AuthService } from '../../core/services/auth.service';
     CommonModule,
     ReactiveFormsModule,
     RouterLink,
-    MatFormFieldModule,
-    MatInputModule,
     MatButtonModule,
-    MatIconModule,
     MatProgressSpinnerModule,
-    TranslateModule
+    TranslateModule,
+    FormFieldComponent,
   ],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss'

--- a/frontend/src/app/features/auth/register.component.html
+++ b/frontend/src/app/features/auth/register.component.html
@@ -35,22 +35,24 @@
           }
         </mat-form-field>
 
-        <mat-form-field appearance="outline" class="half-width">
-          <mat-label>{{ 'auth.register.lastName' | translate }}</mat-label>
-          <input
-            matInput
+        <app-form-field [label]="'auth.register.lastName' | translate" [required]="true">
+  <input
             type="text"
             formControlName="nom"
             [placeholder]="'auth.register.lastNamePlaceholder' | translate"
             autocomplete="family-name"
           >
           @if (registerForm.get('nom')?.hasError('required') && registerForm.get('nom')?.touched) {
-            <mat-error>{{ 'auth.register.errors.lastNameRequired' | translate }}</mat-error>
+            
           }
           @if (registerForm.get('nom')?.hasError('maxlength')) {
-            <mat-error>{{ 'auth.register.errors.maxLength' | translate:{ max: 50 } }}</mat-error>
+            
           }
-        </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'auth.register.errors.lastNameRequired' | translate }}</p>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'auth.register.errors.maxLength' | translate:{ max: 50 } }}</p>
+  </ng-container>
+</app-form-field>
       </div>
 
       <mat-form-field appearance="outline" class="full-width">
@@ -176,19 +178,20 @@
         }
       </mat-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'auth.register.justification' | translate }}</mat-label>
-        <textarea
-          matInput
+      <app-form-field [label]="'auth.register.justification' | translate" [helpText]="'auth.register.justificationHint' | translate">
+  <textarea
           formControlName="justification"
           rows="3"
           [placeholder]="'auth.register.justificationPlaceholder' | translate"
         ></textarea>
-        <mat-hint>{{ 'auth.register.justificationHint' | translate }}</mat-hint>
+        
         @if (registerForm.get('justification')?.hasError('maxlength')) {
-          <mat-error>{{ 'auth.register.errors.maxLength' | translate:{ max: 1000 } }}</mat-error>
+          
         }
-      </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'auth.register.errors.maxLength' | translate:{ max: 1000 } }}</p>
+  </ng-container>
+</app-form-field>
 
       <div class="info-box">
         <i class="fi fi-rr-info"></i>

--- a/frontend/src/app/features/auth/register.component.html
+++ b/frontend/src/app/features/auth/register.component.html
@@ -15,25 +15,22 @@
       }
 
       <div class="form-row">
-        <mat-form-field appearance="outline" class="half-width">
-          <mat-label>{{ 'auth.register.firstName' | translate }}</mat-label>
-          <input
-            matInput
+        <app-form-field [label]="'auth.register.firstName' | translate" [required]="true">
+  <i prefixSlot class="fi fi-rr-user"></i>
+  <input
             type="text"
             formControlName="prenom"
             [placeholder]="'auth.register.firstNamePlaceholder' | translate"
             autocomplete="given-name"
           >
-          <mat-icon matPrefix class="field-icon">
-            <i class="fi fi-rr-user"></i>
-          </mat-icon>
+          
           @if (registerForm.get('prenom')?.hasError('required') && registerForm.get('prenom')?.touched) {
-            <mat-error>{{ 'auth.register.errors.firstNameRequired' | translate }}</mat-error>
+            
           }
           @if (registerForm.get('prenom')?.hasError('maxlength')) {
-            <mat-error>{{ 'auth.register.errors.maxLength' | translate:{ max: 50 } }}</mat-error>
+            
           }
-        </mat-form-field>
+</app-form-field>
 
         <app-form-field [label]="'auth.register.lastName' | translate" [required]="true">
   <input
@@ -55,43 +52,37 @@
 </app-form-field>
       </div>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'auth.register.email' | translate }}</mat-label>
-        <input
-          matInput
+      <app-form-field [label]="'auth.register.email' | translate" [required]="true">
+  <i prefixSlot class="fi fi-rr-envelope"></i>
+  <input
           type="email"
           formControlName="email"
           [placeholder]="'auth.register.emailPlaceholder' | translate"
           autocomplete="email"
         >
-        <mat-icon matPrefix class="field-icon">
-          <i class="fi fi-rr-envelope"></i>
-        </mat-icon>
+        
         @if (registerForm.get('email')?.hasError('required') && registerForm.get('email')?.touched) {
-          <mat-error>{{ 'auth.register.errors.emailRequired' | translate }}</mat-error>
+          
         }
         @if (registerForm.get('email')?.hasError('email') && registerForm.get('email')?.touched) {
-          <mat-error>{{ 'auth.register.errors.emailInvalid' | translate }}</mat-error>
+          
         }
-      </mat-form-field>
+</app-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'auth.register.identifiant' | translate }}</mat-label>
-        <input
-          matInput
+      <app-form-field [label]="'auth.register.identifiant' | translate" [helpText]="'auth.register.identifiantHint' | translate">
+  <i prefixSlot class="fi fi-rr-id-badge"></i>
+  <input
           type="text"
           formControlName="identifiant"
           [placeholder]="'auth.register.identifiantPlaceholder' | translate"
           autocomplete="username"
         >
-        <mat-icon matPrefix class="field-icon">
-          <i class="fi fi-rr-id-badge"></i>
-        </mat-icon>
-        <mat-hint>{{ 'auth.register.identifiantHint' | translate }}</mat-hint>
+        
+        
         @if (registerForm.get('identifiant')?.hasError('maxlength')) {
-          <mat-error>{{ 'auth.register.errors.maxLength' | translate:{ max: 100 } }}</mat-error>
+          
         }
-      </mat-form-field>
+</app-form-field>
 
       <mat-form-field appearance="outline" class="full-width">
         <mat-label>{{ 'auth.register.organisme' | translate }}</mat-label>
@@ -120,63 +111,59 @@
         }
       </mat-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'auth.register.password' | translate }}</mat-label>
-        <input
-          matInput
+      <app-form-field [label]="'auth.register.password' | translate" [required]="true">
+  <i prefixSlot class="fi fi-rr-lock"></i>
+  <input
           [type]="hidePassword() ? 'password' : 'text'"
           formControlName="password"
           [placeholder]="'auth.register.passwordPlaceholder' | translate"
           autocomplete="new-password"
         >
-        <mat-icon matPrefix class="field-icon">
-          <i class="fi fi-rr-lock"></i>
-        </mat-icon>
-        <button
-          mat-icon-button
-          matSuffix
+        
+        
+        @if (registerForm.get('password')?.hasError('required') && registerForm.get('password')?.touched) {
+          
+        }
+        @if (registerForm.get('password')?.hasError('minlength') && registerForm.get('password')?.touched) {
+          
+        }
+  <button suffixSlot
+         
+         
           type="button"
           (click)="togglePasswordVisibility()"
           [attr.aria-label]="(hidePassword() ? 'auth.login.showPassword' : 'auth.login.hidePassword') | translate"
         >
           <i class="fi" [class.fi-rr-eye]="hidePassword()" [class.fi-rr-eye-crossed]="!hidePassword()"></i>
         </button>
-        @if (registerForm.get('password')?.hasError('required') && registerForm.get('password')?.touched) {
-          <mat-error>{{ 'auth.register.errors.passwordRequired' | translate }}</mat-error>
-        }
-        @if (registerForm.get('password')?.hasError('minlength') && registerForm.get('password')?.touched) {
-          <mat-error>{{ 'auth.register.errors.passwordMinLength' | translate }}</mat-error>
-        }
-      </mat-form-field>
+</app-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'auth.register.confirmPassword' | translate }}</mat-label>
-        <input
-          matInput
+      <app-form-field [label]="'auth.register.confirmPassword' | translate" [required]="true">
+  <i prefixSlot class="fi fi-rr-lock"></i>
+  <input
           [type]="hideConfirmPassword() ? 'password' : 'text'"
           formControlName="confirmPassword"
           [placeholder]="'auth.register.confirmPasswordPlaceholder' | translate"
           autocomplete="new-password"
         >
-        <mat-icon matPrefix class="field-icon">
-          <i class="fi fi-rr-lock"></i>
-        </mat-icon>
-        <button
-          mat-icon-button
-          matSuffix
+        
+        
+        @if (registerForm.get('confirmPassword')?.hasError('required') && registerForm.get('confirmPassword')?.touched) {
+          
+        }
+        @if (registerForm.hasError('passwordMismatch') && registerForm.get('confirmPassword')?.touched) {
+          
+        }
+  <button suffixSlot
+         
+         
           type="button"
           (click)="toggleConfirmPasswordVisibility()"
           [attr.aria-label]="(hideConfirmPassword() ? 'auth.login.showPassword' : 'auth.login.hidePassword') | translate"
         >
           <i class="fi" [class.fi-rr-eye]="hideConfirmPassword()" [class.fi-rr-eye-crossed]="!hideConfirmPassword()"></i>
         </button>
-        @if (registerForm.get('confirmPassword')?.hasError('required') && registerForm.get('confirmPassword')?.touched) {
-          <mat-error>{{ 'auth.register.errors.confirmPasswordRequired' | translate }}</mat-error>
-        }
-        @if (registerForm.hasError('passwordMismatch') && registerForm.get('confirmPassword')?.touched) {
-          <mat-error>{{ 'auth.register.errors.passwordMismatch' | translate }}</mat-error>
-        }
-      </mat-form-field>
+</app-form-field>
 
       <app-form-field [label]="'auth.register.justification' | translate" [helpText]="'auth.register.justificationHint' | translate">
   <textarea

--- a/frontend/src/app/features/auth/register.component.html
+++ b/frontend/src/app/features/auth/register.component.html
@@ -84,8 +84,9 @@
         }
 </app-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'auth.register.organisme' | translate }}</mat-label>
+      <label class="app-mat-label">{{ 'auth.register.organisme' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+        <mat-label></mat-label>
         <input
           matInput
           type="text"

--- a/frontend/src/app/features/auth/register.component.ts
+++ b/frontend/src/app/features/auth/register.component.ts
@@ -11,6 +11,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { HttpClient } from '@angular/common/http';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { FormFieldComponent } from '../../shared/components/form-field/form-field.component';
 
 interface OrganismeOption {
   id: number;
@@ -31,7 +32,8 @@ interface OrganismeOption {
     MatProgressSpinnerModule,
     MatSelectModule,
     MatAutocompleteModule,
-    TranslateModule
+    TranslateModule,
+    FormFieldComponent,
   ],
   templateUrl: './register.component.html',
   styleUrl: './register.component.scss'

--- a/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.html
+++ b/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.html
@@ -52,14 +52,13 @@
 
           <div class="form-grid">
             <!-- Intitulé -->
-            <mat-form-field appearance="outline">
-              <mat-label>{{ 'inventaires.form.intitule' | translate }} <span class="required-star">*</span></mat-label>
-              <input matInput formControlName="intitule"
+            <app-form-field [label]="'inventaires.form.intitule' | translate" [required]="true">
+  <input formControlName="intitule"
                 [placeholder]="'inventaires.form.intitulePlaceholder' | translate">
               @if (shouldShowError('intitule')) {
-                <mat-error>{{ getErrorMessage('intitule') }}</mat-error>
+                
               }
-            </mat-form-field>
+</app-form-field>
 
             <!-- Type (codes CS - autocomplete groupé) -->
             <mat-form-field appearance="outline">
@@ -334,16 +333,12 @@
                 <!-- ═══ MODE NON-CAMPANULE (Non) ═══ -->
                 @if (isNotCampanule) {
                   <!-- Nom du protocole (libre) -->
-                  <mat-form-field appearance="outline">
-                    <mat-label>
-                      {{ 'inventaires.form.nomProtocole' | translate }}
-                      <span class="required-star">*</span>
-                    </mat-label>
-                    <input matInput formControlName="nom_protocole">
+                  <app-form-field [label]="'inventaires.form.nomProtocole' | translate" [required]="true">
+  <input formControlName="nom_protocole">
                     @if (shouldShowError('nom_protocole')) {
-                      <mat-error>{{ getErrorMessage('nom_protocole') }}</mat-error>
+                      
                     }
-                  </mat-form-field>
+</app-form-field>
                 }
 
                 <!-- Fréquence de mise en oeuvre (both modes) -->
@@ -422,17 +417,13 @@
                   }
 
                   <!-- Nombre d'ETP par cycle de collecte -->
-                  <mat-form-field appearance="outline">
-                    <mat-label>
-                      {{ 'inventaires.form.nbEtpCycle' | translate }}
-                      <span class="required-star">*</span>
-                    </mat-label>
-                    <input matInput type="number" formControlName="nb_etp_cycle">
-                    <mat-hint>{{ 'inventaires.form.nbEtpCycleHint' | translate }}</mat-hint>
+                  <app-form-field [label]="'inventaires.form.nbEtpCycle' | translate" [required]="true" [helpText]="'inventaires.form.nbEtpCycleHint' | translate">
+  <input type="number" formControlName="nb_etp_cycle">
+                    
                     @if (shouldShowError('nb_etp_cycle')) {
-                      <mat-error>{{ getErrorMessage('nb_etp_cycle') }}</mat-error>
+                      
                     }
-                  </mat-form-field>
+</app-form-field>
 
                   <!-- Descriptif du protocole -->
                   <app-form-field [label]="'inventaires.form.descriptionProtocole' | translate">

--- a/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.html
+++ b/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.html
@@ -272,20 +272,9 @@
         <!-- ═══════════════════════════════════════ -->
         <!-- SECTION: Protocole                      -->
         <!-- ═══════════════════════════════════════ -->
-        <div class="form-card">
-          <div class="section-header" (click)="toggleSection('protocole')">
-            <div class="section-title-row">
-              <span class="section-label">{{ 'inventaires.form.sections.protocole' | translate }}</span>
-            </div>
-            <i class="fi section-chevron"
-              [class.fi-rr-angle-small-down]="sectionsOpen['protocole']"
-              [class.fi-rr-angle-small-right]="!sectionsOpen['protocole']"></i>
-          </div>
-          <div class="section-underline"></div>
-
-          @if (sectionsOpen['protocole']) {
-            <div class="section-content">
-              <div class="form-grid">
+        <app-accordion variant="subtle" [title]="'inventaires.form.sections.protocole' | translate" [expanded]="sectionsOpen['protocole']" (expandedChange)="sectionsOpen['protocole'] = $event">
+  <div class="section-content">
+<div class="form-grid">
                 <!-- Protocole répertorié dans Campanule ? -->
                 <div class="radio-field-row" [class.has-error]="shouldShowError('protocole_dans_campanule')">
                   <span class="radio-field-label">
@@ -546,27 +535,15 @@
                   </mat-form-field>
                 }
               </div>
-            </div>
-          }
-        </div>
+  </div>
+</app-accordion>
 
         <!-- ═══════════════════════════════════════ -->
         <!-- SECTION: Bancarisation et stockage      -->
         <!-- ═══════════════════════════════════════ -->
-        <div class="form-card">
-          <div class="section-header" (click)="toggleSection('bancarisation')">
-            <div class="section-title-row">
-              <span class="section-label">{{ 'inventaires.form.sections.bancarisation' | translate }}</span>
-            </div>
-            <i class="fi section-chevron"
-              [class.fi-rr-angle-small-down]="sectionsOpen['bancarisation']"
-              [class.fi-rr-angle-small-right]="!sectionsOpen['bancarisation']"></i>
-          </div>
-          <div class="section-underline"></div>
-
-          @if (sectionsOpen['bancarisation']) {
-            <div class="section-content">
-              <div class="form-grid">
+        <app-accordion variant="subtle" [title]="'inventaires.form.sections.bancarisation' | translate" [expanded]="sectionsOpen['bancarisation']" (expandedChange)="sectionsOpen['bancarisation'] = $event">
+  <div class="section-content">
+<div class="form-grid">
                 <mat-form-field appearance="outline">
                   <mat-label>{{ 'inventaires.form.outilBancarisation' | translate }}</mat-label>
                   <mat-select formControlName="outil_bancarisation">
@@ -595,36 +572,23 @@
                   </mat-radio-group>
                 </div>
               </div>
-            </div>
-          }
-        </div>
+  </div>
+</app-accordion>
 
         <!-- ═══════════════════════════════════════ -->
         <!-- SECTION: Détails                        -->
         <!-- ═══════════════════════════════════════ -->
-        <div class="form-card">
-          <div class="section-header" (click)="toggleSection('details')">
-            <div class="section-title-row">
-              <span class="section-label">{{ 'inventaires.form.sections.details' | translate }}</span>
-            </div>
-            <i class="fi section-chevron"
-              [class.fi-rr-angle-small-down]="sectionsOpen['details']"
-              [class.fi-rr-angle-small-right]="!sectionsOpen['details']"></i>
-          </div>
-          <div class="section-underline"></div>
-
-          @if (sectionsOpen['details']) {
-            <div class="section-content">
-              <div class="form-grid">
+        <app-accordion variant="subtle" [title]="'inventaires.form.sections.details' | translate" [expanded]="sectionsOpen['details']" (expandedChange)="sectionsOpen['details'] = $event">
+  <div class="section-content">
+<div class="form-grid">
                 <!-- Commentaires -->
                 <mat-form-field appearance="outline">
                   <mat-label>{{ 'inventaires.form.commentaires' | translate }}</mat-label>
                   <textarea matInput formControlName="commentaires" rows="4"></textarea>
                 </mat-form-field>
               </div>
-            </div>
-          }
-        </div>
+  </div>
+</app-accordion>
       </form>
     </div>
 

--- a/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.html
+++ b/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.html
@@ -262,10 +262,9 @@
             </mat-form-field>
 
             <!-- Année de fin -->
-            <mat-form-field appearance="outline">
-              <mat-label>{{ 'inventaires.form.anneeFin' | translate }}</mat-label>
-              <input matInput type="number" formControlName="annee_fin_suivi">
-            </mat-form-field>
+            <app-form-field [label]="'inventaires.form.anneeFin' | translate">
+        <input type="number" formControlName="annee_fin_suivi">
+      </app-form-field>
           </div>
         </div>
 
@@ -378,11 +377,10 @@
                     }
                     <!-- Precision for "Autre" -->
                     @if (showFrequencePrecision) {
-                      <mat-form-field appearance="outline" class="frequence-precision-field">
-                        <mat-label>{{ 'inventaires.form.frequencePrecision' | translate }}</mat-label>
-                        <input matInput formControlName="frequence_unite_precision"
+                      <app-form-field [label]="'inventaires.form.frequencePrecision' | translate">
+        <input formControlName="frequence_unite_precision"
                           [placeholder]="'inventaires.form.frequencePrecisionPlaceholder' | translate">
-                      </mat-form-field>
+      </app-form-field>
                     }
                   </div>
                 }
@@ -417,11 +415,10 @@
 
                   <!-- URL de la documentation (conditional) -->
                   @if (showDocumentationUrl) {
-                    <mat-form-field appearance="outline">
-                      <mat-label>{{ 'inventaires.form.urlDocumentation' | translate }}</mat-label>
-                      <input matInput formControlName="url_documentation"
+                    <app-form-field [label]="'inventaires.form.urlDocumentation' | translate">
+        <input formControlName="url_documentation"
                         [placeholder]="'inventaires.form.urlDocumentationPlaceholder' | translate">
-                    </mat-form-field>
+      </app-form-field>
                   }
 
                   <!-- Nombre d'ETP par cycle de collecte -->
@@ -438,10 +435,9 @@
                   </mat-form-field>
 
                   <!-- Descriptif du protocole -->
-                  <mat-form-field appearance="outline">
-                    <mat-label>{{ 'inventaires.form.descriptionProtocole' | translate }}</mat-label>
-                    <textarea matInput formControlName="description_protocole" rows="3"></textarea>
-                  </mat-form-field>
+                  <app-form-field [label]="'inventaires.form.descriptionProtocole' | translate">
+        <textarea formControlName="description_protocole" rows="3"></textarea>
+      </app-form-field>
                 }
 
                 <!-- ═══ CAMPANULE readonly fields ═══ -->
@@ -473,21 +469,18 @@
 
                 <!-- ═══ NON-CAMPANULE: Objectif du protocole + Période d'échantillonnage ═══ -->
                 @if (isNotCampanule) {
-                  <mat-form-field appearance="outline">
-                    <mat-label>{{ 'inventaires.form.objectifProtocole' | translate }}</mat-label>
-                    <textarea matInput formControlName="objectif_protocole" rows="2"></textarea>
-                  </mat-form-field>
+                  <app-form-field [label]="'inventaires.form.objectifProtocole' | translate">
+        <textarea formControlName="objectif_protocole" rows="2"></textarea>
+      </app-form-field>
 
-                  <mat-form-field appearance="outline">
-                    <mat-label>{{ 'inventaires.form.periodeEchantillonnage' | translate }}</mat-label>
-                    <input matInput formControlName="periode_echantillonnage">
-                  </mat-form-field>
+                  <app-form-field [label]="'inventaires.form.periodeEchantillonnage' | translate">
+        <input formControlName="periode_echantillonnage">
+      </app-form-field>
 
                   <!-- Mode et champ de validation -->
-                  <mat-form-field appearance="outline">
-                    <mat-label>{{ 'inventaires.form.modeValidation' | translate }}</mat-label>
-                    <input matInput formControlName="mode_validation">
-                  </mat-form-field>
+                  <app-form-field [label]="'inventaires.form.modeValidation' | translate">
+        <input formControlName="mode_validation">
+      </app-form-field>
                 }
 
                 <!-- Respect strict du protocole + Consulter le protocole -->
@@ -515,24 +508,20 @@
 
                 <!-- Conditional: non-respect fields -->
                 @if (isNonRespect) {
-                  <mat-form-field appearance="outline">
-                    <mat-label>{{ 'inventaires.form.justificationNonRespect' | translate }}</mat-label>
-                    <textarea matInput formControlName="justification_non_respect" rows="2"></textarea>
-                  </mat-form-field>
+                  <app-form-field [label]="'inventaires.form.justificationNonRespect' | translate">
+        <textarea formControlName="justification_non_respect" rows="2"></textarea>
+      </app-form-field>
 
-                  <mat-form-field appearance="outline">
-                    <mat-label>{{ 'inventaires.form.differencesProtocole' | translate }}</mat-label>
-                    <textarea matInput formControlName="differences_protocole" rows="2"></textarea>
-                  </mat-form-field>
+                  <app-form-field [label]="'inventaires.form.differencesProtocole' | translate">
+        <textarea formControlName="differences_protocole" rows="2"></textarea>
+      </app-form-field>
                 }
 
                 <!-- Nombre d'ETP (campanule mode) -->
                 @if (isCampanule) {
-                  <mat-form-field appearance="outline">
-                    <mat-label>{{ 'inventaires.form.nbEtpCycle' | translate }}</mat-label>
-                    <input matInput type="number" formControlName="nb_etp_cycle">
-                    <mat-hint>{{ 'inventaires.form.nbEtpCycleHint' | translate }}</mat-hint>
-                  </mat-form-field>
+                  <app-form-field [label]="'inventaires.form.nbEtpCycle' | translate" [helpText]="'inventaires.form.nbEtpCycleHint' | translate">
+        <input type="number" formControlName="nb_etp_cycle">
+      </app-form-field>
                 }
               </div>
   </div>
@@ -582,10 +571,9 @@
   <div class="section-content">
 <div class="form-grid">
                 <!-- Commentaires -->
-                <mat-form-field appearance="outline">
-                  <mat-label>{{ 'inventaires.form.commentaires' | translate }}</mat-label>
-                  <textarea matInput formControlName="commentaires" rows="4"></textarea>
-                </mat-form-field>
+                <app-form-field [label]="'inventaires.form.commentaires' | translate">
+        <textarea formControlName="commentaires" rows="4"></textarea>
+      </app-form-field>
               </div>
   </div>
 </app-accordion>

--- a/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.html
+++ b/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.html
@@ -61,8 +61,9 @@
 </app-form-field>
 
             <!-- Type (codes CS - autocomplete groupé) -->
-            <mat-form-field appearance="outline">
-              <mat-label>{{ 'inventaires.form.type' | translate }}</mat-label>
+            <label class="app-mat-label">{{ 'inventaires.form.type' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+              <mat-label></mat-label>
               <input matInput
                 [formControl]="typeActionSearchCtrl"
                 [matAutocomplete]="autoTypeActionInv"
@@ -117,8 +118,9 @@
 
             <!-- Type d'indicateur (conditional: only if suit_indicateur == true) -->
             @if (showTypeIndicateur) {
-              <mat-form-field appearance="outline">
-                <mat-label>{{ 'inventaires.form.typeIndicateur' | translate }} <span class="required-star">*</span></mat-label>
+              <label class="app-mat-label">{{ 'inventaires.form.typeIndicateur' | translate }} <span class="required-star">*</span></label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+                <mat-label></mat-label>
                 <mat-select formControlName="type_indicateur">
                   <mat-option value="">—</mat-option>
                   @for (opt of typeIndicateurOptions(); track opt.id_nomenclature) {
@@ -132,8 +134,9 @@
             }
 
             <!-- Objectif principal (grouped select) -->
-            <mat-form-field appearance="outline">
-              <mat-label>{{ 'inventaires.form.objectifPrincipal' | translate }} <span class="required-star">*</span></mat-label>
+            <label class="app-mat-label">{{ 'inventaires.form.objectifPrincipal' | translate }} <span class="required-star">*</span></label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+              <mat-label></mat-label>
               <mat-select formControlName="objectif_principal">
                 <mat-select-trigger>
                   {{ getObjectifDisplayLabel(form.get('objectif_principal')?.value) }}
@@ -161,8 +164,9 @@
 
             <!-- Objectif secondaire (conditional: only if objectif principal is set) -->
             @if (hasObjectifPrincipal) {
-              <mat-form-field appearance="outline">
-                <mat-label>{{ 'inventaires.form.objectifSecondaire' | translate }}</mat-label>
+              <label class="app-mat-label">{{ 'inventaires.form.objectifSecondaire' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+                <mat-label></mat-label>
                 <mat-select formControlName="objectif_secondaire">
                   <mat-select-trigger>
                     {{ getObjectifDisplayLabel(form.get('objectif_secondaire')?.value) }}
@@ -186,8 +190,9 @@
             }
 
             <!-- Cible principale -->
-            <mat-form-field appearance="outline">
-              <mat-label>{{ 'inventaires.form.ciblesPrincipales' | translate }} <span class="required-star">*</span></mat-label>
+            <label class="app-mat-label">{{ 'inventaires.form.ciblesPrincipales' | translate }} <span class="required-star">*</span></label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+              <mat-label></mat-label>
               <mat-select formControlName="cibles_principales">
                 <mat-option [value]="null">—</mat-option>
                 @for (opt of cibleSuiviOptions(); track opt.id_nomenclature) {
@@ -225,8 +230,9 @@
 
             <!-- Cible secondaire (conditional: only if cible principale is set) -->
             @if (hasCiblePrincipale) {
-              <mat-form-field appearance="outline">
-                <mat-label>{{ 'inventaires.form.cibleSecondaire' | translate }}</mat-label>
+              <label class="app-mat-label">{{ 'inventaires.form.cibleSecondaire' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+                <mat-label></mat-label>
                 <mat-select formControlName="cible_secondaire">
                   <mat-option value="">—</mat-option>
                   @for (opt of cibleSuiviOptions(); track opt.id_nomenclature) {
@@ -238,8 +244,9 @@
             }
 
             <!-- Date de lancement du suivi (date picker) -->
-            <mat-form-field appearance="outline">
-              <mat-label>{{ 'inventaires.form.dateLancement' | translate }} <span class="required-star">*</span></mat-label>
+            <label class="app-mat-label">{{ 'inventaires.form.dateLancement' | translate }} <span class="required-star">*</span></label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+              <mat-label></mat-label>
               <input matInput [matDatepicker]="dateLancementPicker" formControlName="date_lancement_suivi"
                 [placeholder]="'inventaires.form.dateLancementPlaceholder' | translate">
               <mat-datepicker-toggle matSuffix [for]="dateLancementPicker"></mat-datepicker-toggle>
@@ -250,8 +257,9 @@
             </mat-form-field>
 
             <!-- Statut -->
-            <mat-form-field appearance="outline">
-              <mat-label>{{ 'inventaires.form.statut' | translate }}</mat-label>
+            <label class="app-mat-label">{{ 'inventaires.form.statut' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+              <mat-label></mat-label>
               <mat-select formControlName="id_statut">
                 <mat-option [value]="null">—</mat-option>
                 @for (opt of statutSuiviOptions(); track opt.id_nomenclature) {
@@ -291,11 +299,10 @@
                 <!-- ═══ MODE CAMPANULE (Oui) ═══ -->
                 @if (isCampanule) {
                   <!-- Autocomplete Protocole Campanule -->
-                  <mat-form-field appearance="outline">
-                    <mat-label>
-                      {{ 'inventaires.form.protocoleCampanuleNom' | translate }}
-                      <span class="required-star">*</span>
-                    </mat-label>
+                  <label class="app-mat-label">{{ 'inventaires.form.protocoleCampanuleNom' | translate }}
+                      <span class="required-star">*</span></label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+                    <mat-label></mat-label>
                     <input matInput
                       [formControl]="campanuleSearchCtrl"
                       [matAutocomplete]="campanuleAuto"
@@ -383,8 +390,9 @@
                 <!-- ═══ NON-CAMPANULE only fields ═══ -->
                 @if (isNotCampanule) {
                   <!-- Période de suivi (multi-mois) -->
-                  <mat-form-field appearance="outline">
-                    <mat-label>{{ 'inventaires.form.periodeSuivi' | translate }}</mat-label>
+                  <label class="app-mat-label">{{ 'inventaires.form.periodeSuivi' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+                    <mat-label></mat-label>
                     <mat-select formControlName="periode_suivi" multiple>
                       @for (opt of periodeSuiviOptions(); track opt.id_nomenclature) {
                         <mat-option [value]="opt.mnemonique">{{ opt.label }}</mat-option>
@@ -524,8 +532,9 @@
         <app-accordion variant="subtle" [title]="'inventaires.form.sections.bancarisation' | translate" [expanded]="sectionsOpen['bancarisation']" (expandedChange)="sectionsOpen['bancarisation'] = $event">
   <div class="section-content">
 <div class="form-grid">
-                <mat-form-field appearance="outline">
-                  <mat-label>{{ 'inventaires.form.outilBancarisation' | translate }}</mat-label>
+                <label class="app-mat-label">{{ 'inventaires.form.outilBancarisation' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+                  <mat-label></mat-label>
                   <mat-select formControlName="outil_bancarisation">
                     <mat-option [value]="''">—</mat-option>
                     @for (opt of bancarisationOptions(); track opt.mnemonique) {
@@ -534,8 +543,9 @@
                   </mat-select>
                 </mat-form-field>
 
-                <mat-form-field appearance="outline">
-                  <mat-label>{{ 'inventaires.form.outilSaisie' | translate }}</mat-label>
+                <label class="app-mat-label">{{ 'inventaires.form.outilSaisie' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+                  <mat-label></mat-label>
                   <mat-select formControlName="outil_saisie">
                     <mat-option [value]="''">—</mat-option>
                     @for (opt of outilSaisieOptions(); track opt.mnemonique) {

--- a/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.html
+++ b/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.html
@@ -362,7 +362,7 @@
                         <button type="button" class="freq-btn" (click)="incrementFrequence(1)">+</button>
                       </div>
                       <span class="frequence-separator">{{ 'inventaires.form.frequenceFoisPar' | translate }}</span>
-                      <mat-form-field appearance="outline" class="frequence-unite-field">
+                      <mat-form-field appearance="outline" class="frequence-unite-field app-mat-form-field">
                         <mat-select formControlName="frequence_unite">
                           <mat-option value="">—</mat-option>
                           @for (opt of frequenceEmboitementOptions(); track opt.id_nomenclature) {

--- a/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.ts
+++ b/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.ts
@@ -21,6 +21,7 @@ import { debounceTime, distinctUntilChanged, filter, switchMap } from 'rxjs/oper
 
 import { HeaderComponent } from '../../../shared/components/header/header.component';
 import { ReferenceItemListComponent } from '../../../shared/components/reference-item-list/reference-item-list.component';
+import { AccordionComponent } from '../../../shared/components/accordion/accordion.component';
 import { ProtocoleCampanuleDialogComponent } from '../../../shared/components/modals/protocole-campanule-dialog/protocole-campanule-dialog.component';
 import { InventaireService } from '../../../core/services/inventaire.service';
 import { AdminService } from '../../../core/services/admin.service';
@@ -57,7 +58,8 @@ import {
     MatNativeDateModule,
     TranslateModule,
     HeaderComponent,
-    ReferenceItemListComponent
+    ReferenceItemListComponent,
+    AccordionComponent,
   ],
   templateUrl: './inventaire-form.component.html',
   styleUrl: './inventaire-form.component.scss'

--- a/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.ts
+++ b/frontend/src/app/features/inventaires/inventaire-form/inventaire-form.component.ts
@@ -22,6 +22,7 @@ import { debounceTime, distinctUntilChanged, filter, switchMap } from 'rxjs/oper
 import { HeaderComponent } from '../../../shared/components/header/header.component';
 import { ReferenceItemListComponent } from '../../../shared/components/reference-item-list/reference-item-list.component';
 import { AccordionComponent } from '../../../shared/components/accordion/accordion.component';
+import { FormFieldComponent } from '../../../shared/components/form-field/form-field.component';
 import { ProtocoleCampanuleDialogComponent } from '../../../shared/components/modals/protocole-campanule-dialog/protocole-campanule-dialog.component';
 import { InventaireService } from '../../../core/services/inventaire.service';
 import { AdminService } from '../../../core/services/admin.service';
@@ -60,6 +61,7 @@ import {
     HeaderComponent,
     ReferenceItemListComponent,
     AccordionComponent,
+    FormFieldComponent,
   ],
   templateUrl: './inventaire-form.component.html',
   styleUrl: './inventaire-form.component.scss'

--- a/frontend/src/app/features/inventaires/inventaires-list/inventaires-list.component.html
+++ b/frontend/src/app/features/inventaires/inventaires-list/inventaires-list.component.html
@@ -35,16 +35,12 @@
     <!-- Content Area -->
     <section class="content-section">
       <!-- Search Bar -->
-      <div class="search-bar">
-        <i class="fi fi-rr-search search-icon"></i>
-        <input
-          type="text"
-          class="search-input"
-          [ngModel]="searchQuery()"
-          (ngModelChange)="onSearch($event)"
-          [placeholder]="'common.actions.search' | translate">
-        <div class="search-underline"></div>
-      </div>
+      <app-search-bar
+        [value]="searchQuery()"
+        [placeholder]="'common.actions.search' | translate"
+        [ariaLabel]="'common.actions.search' | translate"
+        (valueChange)="onSearch($event)">
+      </app-search-bar>
 
       <!-- Filter Bar + Add Button Row -->
       <div class="toolbar-row">

--- a/frontend/src/app/features/inventaires/inventaires-list/inventaires-list.component.ts
+++ b/frontend/src/app/features/inventaires/inventaires-list/inventaires-list.component.ts
@@ -12,6 +12,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 import { HeaderComponent } from '../../../shared/components/header/header.component';
+import { SearchBarComponent } from '../../../shared/components/search-bar/search-bar.component';
 import { InventaireService } from '../../../core/services/inventaire.service';
 import { AdminService } from '../../../core/services/admin.service';
 import { SuiviInventaireList } from '../../../core/models/inventaire.model';
@@ -27,7 +28,8 @@ import { SuiviInventaireList } from '../../../core/models/inventaire.model';
     MatMenuModule,
     MatProgressSpinnerModule,
     TranslateModule,
-    HeaderComponent
+    HeaderComponent,
+    SearchBarComponent,
   ],
   templateUrl: './inventaires-list.component.html',
   styleUrl: './inventaires-list.component.scss'

--- a/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.html
@@ -48,7 +48,7 @@
           </mat-form-field>
 
           <!-- Intitulé court -->
-          <mat-form-field appearance="outline" class="full-width">
+          <mat-form-field appearance="outline">
             <mat-label>{{ 'enjeux.enjeuForm.intituleCourt' | translate }} <span class="required-star">*</span></mat-label>
             <input matInput
                    formControlName="intitule_court"
@@ -151,13 +151,12 @@
             <!-- Précision "Autre écologique" (si coché) -->
             @if (form.get('autre_ecologique')?.value) {
               <div class="form-group sub-question">
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>{{ 'enjeux.enjeuForm.autreEcologiquePrecision' | translate }}</mat-label>
-                  <input matInput
+                <app-form-field [label]="'enjeux.enjeuForm.autreEcologiquePrecision' | translate">
+  <input
                          formControlName="autre_ecologique_precision"
                          maxlength="255"
                          [placeholder]="'enjeux.enjeuForm.autreEcologiquePrecisionPlaceholder' | translate">
-                </mat-form-field>
+</app-form-field>
               </div>
             }
           } @else {
@@ -177,13 +176,12 @@
             <!-- Précision "Autre socio-économique" (si coché) -->
             @if (form.get('autre_socioeco')?.value) {
               <div class="form-group sub-question">
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>{{ 'enjeux.enjeuForm.autreSocioEcoPrecision' | translate }}</mat-label>
-                  <input matInput
+                <app-form-field [label]="'enjeux.enjeuForm.autreSocioEcoPrecision' | translate">
+  <input
                          formControlName="autre_socioeco_precision"
                          maxlength="255"
                          [placeholder]="'enjeux.enjeuForm.autreSocioEcoPrecisionPlaceholder' | translate">
-                </mat-form-field>
+</app-form-field>
               </div>
             }
           }
@@ -195,24 +193,22 @@
 
           <div class="panel-content">
             <!-- État de l'enjeu -->
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'enjeux.enjeuForm.etatEnjeu' | translate }}</mat-label>
-              <textarea matInput
+            <app-form-field [label]="'enjeux.enjeuForm.etatEnjeu' | translate">
+  <textarea
                         formControlName="etat_enjeu"
                         rows="4"
                         [placeholder]="'enjeux.enjeuForm.etatEnjeuPlaceholder' | translate">
               </textarea>
-            </mat-form-field>
+</app-form-field>
 
             <!-- Commentaires -->
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'enjeux.enjeuForm.commentaires' | translate }}</mat-label>
-              <textarea matInput
+            <app-form-field [label]="'enjeux.enjeuForm.commentaires' | translate">
+  <textarea
                         formControlName="description"
                         rows="4"
                         [placeholder]="'enjeux.enjeuForm.commentairesPlaceholder' | translate">
               </textarea>
-            </mat-form-field>
+</app-form-field>
           </div>
         </app-accordion>
 

--- a/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.html
@@ -32,20 +32,19 @@
           <!-- Required fields notice -->
           <p class="required-notice">{{ 'enjeux.enjeuForm.requiredBefore' | translate }} <span class="required-star">*</span> {{ 'enjeux.enjeuForm.requiredAfter' | translate }}</p>
           <!-- Intitulé -->
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'enjeux.enjeuForm.libelle' | translate }} <span class="required-star">*</span></mat-label>
-            <textarea matInput
+          <app-form-field [label]="'enjeux.enjeuForm.libelle' | translate" [required]="true">
+  <textarea
                       formControlName="libelle"
                       rows="3"
                       [placeholder]="'enjeux.enjeuForm.libellePlaceholder' | translate">
             </textarea>
             @if (form.get('libelle')?.hasError('required') && form.get('libelle')?.touched) {
-              <mat-error>{{ 'common.validation.required' | translate }}</mat-error>
+              
             }
             @if (form.get('libelle')?.hasError('maxlength')) {
-              <mat-error>{{ 'common.validation.maxLength' | translate:{ max: 500 } }}</mat-error>
+              
             }
-          </mat-form-field>
+</app-form-field>
 
           <!-- Intitulé court -->
           <mat-form-field appearance="outline">

--- a/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.html
@@ -215,15 +215,9 @@
           }
         </div>
 
-        <!-- Section Détails (accordéon) -->
-        <mat-expansion-panel class="details-panel" hideToggle>
-          <mat-expansion-panel-header>
-            <mat-panel-title>
-              <img src="assets/images/ellipses/ellipse-terra-cotta.png" alt="" class="panel-ellipse">
-              <span class="panel-title-text">{{ 'enjeux.enjeuForm.details' | translate }}</span>
-              <i class="fi fi-rr-menu-burger panel-toggle-icon"></i>
-            </mat-panel-title>
-          </mat-expansion-panel-header>
+        <!-- Section Détails (#303 accordion enjeu) -->
+        <app-accordion variant="enjeu" [title]="'enjeux.enjeuForm.details' | translate">
+          <img accordionIcon src="assets/images/ellipses/ellipse-terra-cotta.png" alt="" class="panel-ellipse">
 
           <div class="panel-content">
             <!-- État de l'enjeu -->
@@ -246,7 +240,7 @@
               </textarea>
             </mat-form-field>
           </div>
-        </mat-expansion-panel>
+        </app-accordion>
 
       </form>
     </div>

--- a/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.html
@@ -96,21 +96,11 @@
             <div class="form-group">
               <label class="form-label">{{ 'enjeux.enjeuForm.enjeuLieAEcologique' | translate }}</label>
               <div class="checkbox-group">
-                <mat-checkbox formControlName="habitat" color="primary">
-                  {{ 'enjeux.enjeuForm.habitat' | translate }}
-                </mat-checkbox>
-                <mat-checkbox formControlName="espece" color="primary">
-                  {{ 'enjeux.enjeuForm.espece' | translate }}
-                </mat-checkbox>
-                <mat-checkbox formControlName="patrimoine_geologique" color="primary">
-                  {{ 'enjeux.enjeuForm.patrimoineGeologique' | translate }}
-                </mat-checkbox>
-                <mat-checkbox formControlName="fonctionnalite_ecosysteme" color="primary">
-                  {{ 'enjeux.enjeuForm.fonctionnaliteEcosysteme' | translate }}
-                </mat-checkbox>
-                <mat-checkbox formControlName="autre_ecologique" color="primary">
-                  {{ 'enjeux.enjeuForm.autreEcologique' | translate }}
-                </mat-checkbox>
+                <app-checkbox formControlName="habitat" [label]="'enjeux.enjeuForm.habitat' | translate"></app-checkbox>
+                <app-checkbox formControlName="espece" [label]="'enjeux.enjeuForm.espece' | translate"></app-checkbox>
+                <app-checkbox formControlName="patrimoine_geologique" [label]="'enjeux.enjeuForm.patrimoineGeologique' | translate"></app-checkbox>
+                <app-checkbox formControlName="fonctionnalite_ecosysteme" [label]="'enjeux.enjeuForm.fonctionnaliteEcosysteme' | translate"></app-checkbox>
+                <app-checkbox formControlName="autre_ecologique" [label]="'enjeux.enjeuForm.autreEcologique' | translate"></app-checkbox>
               </div>
             </div>
 
@@ -143,12 +133,8 @@
               <div class="form-group sub-question">
                 <label class="form-label">{{ 'enjeux.enjeuForm.typePatrimoineGeo' | translate }}</label>
                 <div class="checkbox-group">
-                  <mat-checkbox formControlName="geo_ex_situ" color="primary">
-                    {{ 'enjeux.enjeuForm.geoExSitu' | translate }}
-                  </mat-checkbox>
-                  <mat-checkbox formControlName="geo_in_situ" color="primary">
-                    {{ 'enjeux.enjeuForm.geoInSitu' | translate }}
-                  </mat-checkbox>
+                  <app-checkbox formControlName="geo_ex_situ" [label]="'enjeux.enjeuForm.geoExSitu' | translate"></app-checkbox>
+                  <app-checkbox formControlName="geo_in_situ" [label]="'enjeux.enjeuForm.geoInSitu' | translate"></app-checkbox>
                 </div>
               </div>
 
@@ -179,24 +165,12 @@
             <div class="form-group">
               <label class="form-label">{{ 'enjeux.enjeuForm.enjeuLieASocioEco' | translate }}</label>
               <div class="checkbox-group">
-                <mat-checkbox formControlName="valeur_paysagere" color="primary">
-                  {{ 'enjeux.enjeuForm.valeurPaysagere' | translate }}
-                </mat-checkbox>
-                <mat-checkbox formControlName="patrimoine_culturel" color="primary">
-                  {{ 'enjeux.enjeuForm.patrimoineCulturel' | translate }}
-                </mat-checkbox>
-                <mat-checkbox formControlName="developpement_durable" color="primary">
-                  {{ 'enjeux.enjeuForm.developpementDurable' | translate }}
-                </mat-checkbox>
-                <mat-checkbox formControlName="usages" color="primary">
-                  {{ 'enjeux.enjeuForm.usages' | translate }}
-                </mat-checkbox>
-                <mat-checkbox formControlName="valeur_ajoutee" color="primary">
-                  {{ 'enjeux.enjeuForm.valeurAjoutee' | translate }}
-                </mat-checkbox>
-                <mat-checkbox formControlName="autre_socioeco" color="primary">
-                  {{ 'enjeux.enjeuForm.autreSocioEco' | translate }}
-                </mat-checkbox>
+                <app-checkbox formControlName="valeur_paysagere" [label]="'enjeux.enjeuForm.valeurPaysagere' | translate"></app-checkbox>
+                <app-checkbox formControlName="patrimoine_culturel" [label]="'enjeux.enjeuForm.patrimoineCulturel' | translate"></app-checkbox>
+                <app-checkbox formControlName="developpement_durable" [label]="'enjeux.enjeuForm.developpementDurable' | translate"></app-checkbox>
+                <app-checkbox formControlName="usages" [label]="'enjeux.enjeuForm.usages' | translate"></app-checkbox>
+                <app-checkbox formControlName="valeur_ajoutee" [label]="'enjeux.enjeuForm.valeurAjoutee' | translate"></app-checkbox>
+                <app-checkbox formControlName="autre_socioeco" [label]="'enjeux.enjeuForm.autreSocioEco' | translate"></app-checkbox>
               </div>
             </div>
 

--- a/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.html
@@ -47,19 +47,18 @@
 </app-form-field>
 
           <!-- Intitulé court -->
-          <mat-form-field appearance="outline">
-            <mat-label>{{ 'enjeux.enjeuForm.intituleCourt' | translate }} <span class="required-star">*</span></mat-label>
-            <input matInput
-                   formControlName="intitule_court"
+          <app-form-field [label]="'enjeux.enjeuForm.intituleCourt' | translate"
+                          [required]="true"
+                          [helpText]="intituleCourtLength + '/25'">
+            <input formControlName="intitule_court"
                    maxlength="25"
                    [placeholder]="'enjeux.enjeuForm.intituleCourtPlaceholder' | translate">
-            <mat-hint align="end">{{ intituleCourtLength }}/25</mat-hint>
-            <button mat-icon-button matSuffix type="button"
+            <button suffixSlot type="button"
                     [matTooltip]="'enjeux.enjeuForm.intituleCourtHint' | translate"
                     matTooltipPosition="above">
               <i class="fi fi-rr-interrogation"></i>
             </button>
-          </mat-form-field>
+          </app-form-field>
 
           <!-- Priorité -->
           <div class="form-group">

--- a/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.ts
+++ b/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.ts
@@ -465,7 +465,7 @@ export class EnjeuFormComponent implements OnInit {
         banner.scrollIntoView({ behavior: 'smooth', block: 'center' });
         return;
       }
-      const invalid = this.elRef.nativeElement.querySelector('mat-form-field.ng-invalid');
+      const invalid = this.elRef.nativeElement.querySelector('input.ng-invalid, textarea.ng-invalid, mat-form-field.ng-invalid');
       invalid?.scrollIntoView({ behavior: 'smooth', block: 'center' });
     });
   }

--- a/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.ts
+++ b/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.ts
@@ -12,13 +12,13 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatExpansionModule } from '@angular/material/expansion';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 import { HeaderComponent } from '../../../../shared/components/header/header.component';
 import { ReferenceItemListComponent } from '../../../../shared/components/reference-item-list/reference-item-list.component';
+import { AccordionComponent } from '../../../../shared/components/accordion/accordion.component';
 import { EnjeuService } from '../../../../core/services/enjeu.service';
 import { AdminService } from '../../../../core/services/admin.service';
 import { Enjeu, EnjeuCreatePayload, EnjeuUpdatePayload, TaxonRef, HabitatRef, GeologieRef } from '../../../../core/models/enjeu.model';
@@ -35,12 +35,12 @@ import { Enjeu, EnjeuCreatePayload, EnjeuUpdatePayload, TaxonRef, HabitatRef, Ge
     MatRadioModule,
     MatCheckboxModule,
     MatProgressSpinnerModule,
-    MatExpansionModule,
     MatTooltipModule,
     MatSnackBarModule,
     TranslateModule,
     HeaderComponent,
-    ReferenceItemListComponent
+    ReferenceItemListComponent,
+    AccordionComponent,
   ],
   templateUrl: './enjeu-form.component.html',
   styleUrl: './enjeu-form.component.scss'

--- a/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.ts
+++ b/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.ts
@@ -19,6 +19,7 @@ import { HeaderComponent } from '../../../../shared/components/header/header.com
 import { ReferenceItemListComponent } from '../../../../shared/components/reference-item-list/reference-item-list.component';
 import { AccordionComponent } from '../../../../shared/components/accordion/accordion.component';
 import { CheckboxComponent } from '../../../../shared/components/checkbox/checkbox.component';
+import { FormFieldComponent } from '../../../../shared/components/form-field/form-field.component';
 import { EnjeuService } from '../../../../core/services/enjeu.service';
 import { AdminService } from '../../../../core/services/admin.service';
 import { Enjeu, EnjeuCreatePayload, EnjeuUpdatePayload, TaxonRef, HabitatRef, GeologieRef } from '../../../../core/models/enjeu.model';
@@ -34,6 +35,7 @@ import { Enjeu, EnjeuCreatePayload, EnjeuUpdatePayload, TaxonRef, HabitatRef, Ge
     MatButtonModule,
     MatRadioModule,
     CheckboxComponent,
+    FormFieldComponent,
     MatProgressSpinnerModule,
     MatTooltipModule,
     MatSnackBarModule,

--- a/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.ts
+++ b/frontend/src/app/features/plans/enjeux/enjeu-form/enjeu-form.component.ts
@@ -10,7 +10,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatRadioModule } from '@angular/material/radio';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
@@ -19,6 +18,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { HeaderComponent } from '../../../../shared/components/header/header.component';
 import { ReferenceItemListComponent } from '../../../../shared/components/reference-item-list/reference-item-list.component';
 import { AccordionComponent } from '../../../../shared/components/accordion/accordion.component';
+import { CheckboxComponent } from '../../../../shared/components/checkbox/checkbox.component';
 import { EnjeuService } from '../../../../core/services/enjeu.service';
 import { AdminService } from '../../../../core/services/admin.service';
 import { Enjeu, EnjeuCreatePayload, EnjeuUpdatePayload, TaxonRef, HabitatRef, GeologieRef } from '../../../../core/models/enjeu.model';
@@ -33,7 +33,7 @@ import { Enjeu, EnjeuCreatePayload, EnjeuUpdatePayload, TaxonRef, HabitatRef, Ge
     MatInputModule,
     MatButtonModule,
     MatRadioModule,
-    MatCheckboxModule,
+    CheckboxComponent,
     MatProgressSpinnerModule,
     MatTooltipModule,
     MatSnackBarModule,

--- a/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.html
+++ b/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.html
@@ -437,8 +437,9 @@
   <input [(ngModel)]="editPressionLibelle">
 </app-form-field>
                                     <!-- PressRef autocomplete (edit) -->
-                                    <mat-form-field appearance="outline" class="full-width">
-                                      <mat-label>{{ 'enjeux.pression.pressrefLabel' | translate }}</mat-label>
+                                    <label class="app-mat-label">{{ 'enjeux.pression.pressrefLabel' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+                                      <mat-label></mat-label>
                                       <input matInput
                                         [formControl]="editPressrefSearchCtrl"
                                         [matAutocomplete]="autoEditPressref"
@@ -554,8 +555,9 @@
                             </div>
                             <div class="inline-form-body">
                               <!-- PressRef autocomplete (au-dessus du libellé pour éviter d'écraser la saisie) -->
-                              <mat-form-field appearance="outline" class="full-width">
-                                <mat-label>{{ 'enjeux.pression.pressrefLabel' | translate }}</mat-label>
+                              <label class="app-mat-label">{{ 'enjeux.pression.pressrefLabel' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+                                <mat-label></mat-label>
                                 <input matInput
                                   [formControl]="pressrefSearchCtrl"
                                   [matAutocomplete]="autoPressref"
@@ -920,8 +922,9 @@
                                                       <app-form-field [label]="'enjeux.metriques.uniteLabel' | translate">
   <input [(ngModel)]="met.unite">
 </app-form-field>
-                                                      <mat-form-field appearance="outline">
-                                                        <mat-label>{{ 'enjeux.metriques.typeLabel' | translate }}</mat-label>
+                                                      <label class="app-mat-label">{{ 'enjeux.metriques.typeLabel' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+                                                        <mat-label></mat-label>
                                                         <mat-select [(ngModel)]="met.type_metrique">
                                                           @for (opt of typeMetriqueOptions(); track opt.id_nomenclature) {
                                                             <mat-option [value]="opt.id_nomenclature">{{ opt.label }}</mat-option>
@@ -1525,8 +1528,9 @@
                                                     <app-form-field [label]="'enjeux.metriques.uniteLabel' | translate">
   <input [(ngModel)]="standaloneMetriqueForm.unite">
 </app-form-field>
-                                                    <mat-form-field appearance="outline">
-                                                      <mat-label>{{ 'enjeux.metriques.typeLabel' | translate }}</mat-label>
+                                                    <label class="app-mat-label">{{ 'enjeux.metriques.typeLabel' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+                                                      <mat-label></mat-label>
                                                       <mat-select [(ngModel)]="standaloneMetriqueForm.type_metrique">
                                                         @for (opt of typeMetriqueOptions(); track opt.id_nomenclature) {
                                                           <mat-option [value]="opt.id_nomenclature">{{ opt.label }}</mat-option>
@@ -1739,8 +1743,9 @@
                                                 <app-form-field [label]="'enjeux.metriques.uniteLabel' | translate">
   <input [(ngModel)]="met.unite">
 </app-form-field>
-                                                <mat-form-field appearance="outline">
-                                                  <mat-label>{{ 'enjeux.metriques.typeLabel' | translate }}</mat-label>
+                                                <label class="app-mat-label">{{ 'enjeux.metriques.typeLabel' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+                                                  <mat-label></mat-label>
                                                   <mat-select [(ngModel)]="met.type_metrique">
                                                     @for (opt of typeMetriqueOptions(); track opt.id_nomenclature) {
                                                       <mat-option [value]="opt.id_nomenclature">{{ opt.label }}</mat-option>
@@ -1987,8 +1992,9 @@
                       <app-form-field class="full-width" [label]="'enjeux.oo.descriptionLabel' | translate">
   <textarea [(ngModel)]="editOoDescription" rows="2"></textarea>
 </app-form-field>
-                      <mat-form-field class="full-width" appearance="outline">
-                        <mat-label>{{ 'enjeux.oo.pressionLabel' | translate }} *</mat-label>
+                      <label class="app-mat-label">{{ 'enjeux.oo.pressionLabel' | translate }} *</label>
+      <mat-form-field class="full-width app-mat-form-field" appearance="outline">
+                        <mat-label></mat-label>
                         <mat-select [(ngModel)]="editOoPressionIds" multiple required>
                           @for (fi of selectedFacteurs(); track fi.id_facteur_influence) {
                             <mat-optgroup [label]="fi.libelle">
@@ -2253,8 +2259,9 @@
                                               <app-form-field [label]="'enjeux.metriques.uniteLabel' | translate">
   <input [(ngModel)]="met.unite">
 </app-form-field>
-                                              <mat-form-field appearance="outline">
-                                                <mat-label>{{ 'enjeux.metriques.typeLabel' | translate }}</mat-label>
+                                              <label class="app-mat-label">{{ 'enjeux.metriques.typeLabel' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+                                                <mat-label></mat-label>
                                                 <mat-select [(ngModel)]="met.type_metrique">
                                                   @for (opt of typeMetriqueOptions(); track opt.id_nomenclature) {
                                                     <mat-option [value]="opt.id_nomenclature">{{ opt.label }}</mat-option>
@@ -2838,8 +2845,9 @@
                                             <app-form-field [label]="'enjeux.metriques.uniteLabel' | translate">
   <input [(ngModel)]="standaloneMetriqueForm.unite">
 </app-form-field>
-                                            <mat-form-field appearance="outline">
-                                              <mat-label>{{ 'enjeux.metriques.typeLabel' | translate }}</mat-label>
+                                            <label class="app-mat-label">{{ 'enjeux.metriques.typeLabel' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+                                              <mat-label></mat-label>
                                               <mat-select [(ngModel)]="standaloneMetriqueForm.type_metrique">
                                                 @for (opt of typeMetriqueOptions(); track opt.id_nomenclature) {
                                                   <mat-option [value]="opt.id_nomenclature">{{ opt.label }}</mat-option>
@@ -3046,8 +3054,9 @@
                                         <app-form-field [label]="'enjeux.metriques.uniteLabel' | translate">
   <input [(ngModel)]="met.unite">
 </app-form-field>
-                                        <mat-form-field appearance="outline">
-                                          <mat-label>{{ 'enjeux.metriques.typeLabel' | translate }}</mat-label>
+                                        <label class="app-mat-label">{{ 'enjeux.metriques.typeLabel' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+                                          <mat-label></mat-label>
                                           <mat-select [(ngModel)]="met.type_metrique">
                                             @for (opt of typeMetriqueOptions(); track opt.id_nomenclature) {
                                               <mat-option [value]="opt.id_nomenclature">{{ opt.label }}</mat-option>
@@ -3221,8 +3230,9 @@
                     <app-form-field class="full-width" [label]="'enjeux.oo.descriptionLabel' | translate">
   <textarea [(ngModel)]="newOoDescription" rows="2"></textarea>
 </app-form-field>
-                    <mat-form-field class="full-width" appearance="outline">
-                      <mat-label>{{ 'enjeux.oo.pressionLabel' | translate }} *</mat-label>
+                    <label class="app-mat-label">{{ 'enjeux.oo.pressionLabel' | translate }} *</label>
+      <mat-form-field class="full-width app-mat-form-field" appearance="outline">
+                      <mat-label></mat-label>
                       <mat-select [(ngModel)]="newOoPressionIds" multiple required>
                         @for (fi of selectedFacteurs(); track fi.id_facteur_influence) {
                           <mat-optgroup [label]="fi.libelle">

--- a/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.html
+++ b/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.html
@@ -354,14 +354,12 @@
                             <h4 class="inline-form-title">{{ 'enjeux.facteurInfluence.editTitle' | translate }}</h4>
                           </div>
                           <div class="inline-form-body">
-                            <mat-form-field class="full-width" appearance="outline">
-                              <mat-label>{{ 'enjeux.facteurInfluence.libelleLabel' | translate }}</mat-label>
-                              <input matInput [(ngModel)]="editFacteurLibelle">
-                            </mat-form-field>
-                            <mat-form-field class="full-width" appearance="outline">
-                              <mat-label>{{ 'enjeux.facteurInfluence.descriptionLabel' | translate }}</mat-label>
-                              <textarea matInput [(ngModel)]="editFacteurDescription" rows="2"></textarea>
-                            </mat-form-field>
+                            <app-form-field class="full-width" [label]="'enjeux.facteurInfluence.libelleLabel' | translate">
+  <input [(ngModel)]="editFacteurLibelle">
+</app-form-field>
+                            <app-form-field class="full-width" [label]="'enjeux.facteurInfluence.descriptionLabel' | translate">
+  <textarea [(ngModel)]="editFacteurDescription" rows="2"></textarea>
+</app-form-field>
                           </div>
                           <div class="inline-form-actions">
                             <button mat-flat-button color="primary" (click)="saveEditFacteur(facteur)" [disabled]="!editFacteurLibelle.trim()">
@@ -435,10 +433,9 @@
                                     <h4 class="inline-form-title">{{ 'enjeux.pression.editTitle' | translate }}</h4>
                                   </div>
                                   <div class="inline-form-body">
-                                    <mat-form-field class="full-width" appearance="outline">
-                                      <mat-label>{{ 'enjeux.pression.libelleLabel' | translate }}</mat-label>
-                                      <input matInput [(ngModel)]="editPressionLibelle">
-                                    </mat-form-field>
+                                    <app-form-field class="full-width" [label]="'enjeux.pression.libelleLabel' | translate">
+  <input [(ngModel)]="editPressionLibelle">
+</app-form-field>
                                     <!-- PressRef autocomplete (edit) -->
                                     <mat-form-field appearance="outline" class="full-width">
                                       <mat-label>{{ 'enjeux.pression.pressrefLabel' | translate }}</mat-label>
@@ -473,10 +470,9 @@
                                       </mat-autocomplete>
                                       <mat-hint>{{ 'enjeux.pression.pressrefHint' | translate }}</mat-hint>
                                     </mat-form-field>
-                                    <mat-form-field class="full-width" appearance="outline">
-                                      <mat-label>{{ 'enjeux.pression.descriptionLabel' | translate }}</mat-label>
-                                      <textarea matInput [(ngModel)]="editPressionDescription" rows="2"></textarea>
-                                    </mat-form-field>
+                                    <app-form-field class="full-width" [label]="'enjeux.pression.descriptionLabel' | translate">
+  <textarea [(ngModel)]="editPressionDescription" rows="2"></textarea>
+</app-form-field>
                                   </div>
                                   <div class="inline-form-actions">
                                     <button mat-flat-button color="primary" (click)="saveEditPression(pression)" [disabled]="!editPressionLibelle.trim()">
@@ -592,14 +588,12 @@
                                 <mat-hint>{{ 'enjeux.pression.pressrefHint' | translate }}</mat-hint>
                               </mat-form-field>
                               <!-- Libellé de la pression -->
-                              <mat-form-field appearance="outline" class="full-width">
-                                <mat-label>{{ 'enjeux.pression.libelleLabel' | translate }}</mat-label>
-                                <input matInput [(ngModel)]="newPressionLibelle">
-                              </mat-form-field>
-                              <mat-form-field appearance="outline" class="full-width">
-                                <mat-label>{{ 'enjeux.pression.descriptionLabel' | translate }}</mat-label>
-                                <textarea matInput [(ngModel)]="newPressionDescription" rows="3"></textarea>
-                              </mat-form-field>
+                              <app-form-field [label]="'enjeux.pression.libelleLabel' | translate">
+  <input [(ngModel)]="newPressionLibelle">
+</app-form-field>
+                              <app-form-field [label]="'enjeux.pression.descriptionLabel' | translate">
+  <textarea [(ngModel)]="newPressionDescription" rows="3"></textarea>
+</app-form-field>
                             </div>
                             <div class="inline-form-actions">
                               <button mat-flat-button color="primary" (click)="savePression(facteur)" [disabled]="!newPressionLibelle.trim()">
@@ -631,14 +625,12 @@
                       <h4 class="inline-form-title">{{ 'enjeux.facteurInfluence.newTitle' | translate }}</h4>
                     </div>
                     <div class="inline-form-body">
-                      <mat-form-field appearance="outline" class="full-width">
-                        <mat-label>{{ 'enjeux.facteurInfluence.libelleLabel' | translate }}</mat-label>
-                        <input matInput [(ngModel)]="newFacteurLibelle">
-                      </mat-form-field>
-                      <mat-form-field appearance="outline" class="full-width">
-                        <mat-label>{{ 'enjeux.facteurInfluence.descriptionLabel' | translate }}</mat-label>
-                        <textarea matInput [(ngModel)]="newFacteurDescription" rows="3"></textarea>
-                      </mat-form-field>
+                      <app-form-field [label]="'enjeux.facteurInfluence.libelleLabel' | translate">
+  <input [(ngModel)]="newFacteurLibelle">
+</app-form-field>
+                      <app-form-field [label]="'enjeux.facteurInfluence.descriptionLabel' | translate">
+  <textarea [(ngModel)]="newFacteurDescription" rows="3"></textarea>
+</app-form-field>
                     </div>
                     <div class="inline-form-actions">
                       <button mat-flat-button color="primary" (click)="saveFacteurInfluence()" [disabled]="!newFacteurLibelle.trim()">
@@ -687,14 +679,12 @@
                               <h4 class="inline-form-title">{{ 'enjeux.olt.editTitle' | translate }}</h4>
                             </div>
                             <div class="inline-form-body">
-                              <mat-form-field class="full-width" appearance="outline">
-                                <mat-label>{{ 'enjeux.olt.libelleLabel' | translate }}</mat-label>
-                                <input matInput [(ngModel)]="editOltLibelle">
-                              </mat-form-field>
-                              <mat-form-field class="full-width" appearance="outline">
-                                <mat-label>{{ 'enjeux.olt.descriptionLabel' | translate }}</mat-label>
-                                <textarea matInput [(ngModel)]="editOltDescription" rows="2"></textarea>
-                              </mat-form-field>
+                              <app-form-field class="full-width" [label]="'enjeux.olt.libelleLabel' | translate">
+  <input [(ngModel)]="editOltLibelle">
+</app-form-field>
+                              <app-form-field class="full-width" [label]="'enjeux.olt.descriptionLabel' | translate">
+  <textarea [(ngModel)]="editOltDescription" rows="2"></textarea>
+</app-form-field>
                             </div>
                             <div class="inline-form-actions">
                               <button mat-flat-button color="primary" (click)="saveEditOlt(olt)" [disabled]="!editOltLibelle.trim()">
@@ -759,14 +749,12 @@
                                 @if (editingNeId() === ne.id_ne) {
                                   <div class="inline-form ne-inline-form">
                                     <div class="inline-form-body">
-                                      <mat-form-field class="full-width" appearance="outline">
-                                        <mat-label>{{ 'enjeux.niveauExigence.libelleLabel' | translate }}</mat-label>
-                                        <input matInput [(ngModel)]="editNeLibelle">
-                                      </mat-form-field>
-                                      <mat-form-field class="full-width" appearance="outline">
-                                        <mat-label>{{ 'enjeux.niveauExigence.descriptionLabel' | translate }}</mat-label>
-                                        <textarea matInput [(ngModel)]="editNeDescription" rows="2"></textarea>
-                                      </mat-form-field>
+                                      <app-form-field class="full-width" [label]="'enjeux.niveauExigence.libelleLabel' | translate">
+  <input [(ngModel)]="editNeLibelle">
+</app-form-field>
+                                      <app-form-field class="full-width" [label]="'enjeux.niveauExigence.descriptionLabel' | translate">
+  <textarea [(ngModel)]="editNeDescription" rows="2"></textarea>
+</app-form-field>
                                     </div>
                                     <div class="inline-form-actions">
                                       <button mat-flat-button color="primary" (click)="saveEditNe(ne)" [disabled]="!editNeLibelle.trim()">
@@ -838,10 +826,9 @@
                                             </div>
 
                                             <!-- Intitulé indicateur -->
-                                            <mat-form-field appearance="outline" class="full-width">
-                                              <mat-label>{{ 'enjeux.indicateurs.nomLabel' | translate }} *</mat-label>
-                                              <input matInput [(ngModel)]="editIndicateurNom">
-                                            </mat-form-field>
+                                            <app-form-field [label]="('enjeux.indicateurs.nomLabel' | translate) + ' *'">
+  <input [(ngModel)]="editIndicateurNom">
+</app-form-field>
 
                                             <!-- Indicateur standardisé -->
                                             <div class="form-radio-row">
@@ -853,10 +840,9 @@
                                             </div>
 
                                             <!-- Description -->
-                                            <mat-form-field appearance="outline" class="full-width">
-                                              <mat-label>{{ 'enjeux.indicateurs.descriptionLabel' | translate }}</mat-label>
-                                              <textarea matInput [(ngModel)]="editIndicateurDescription" rows="3"></textarea>
-                                            </mat-form-field>
+                                            <app-form-field [label]="'enjeux.indicateurs.descriptionLabel' | translate">
+  <textarea [(ngModel)]="editIndicateurDescription" rows="3"></textarea>
+</app-form-field>
 
                                             <!-- Section MÉTRIQUES -->
                                             <div class="metriques-section">
@@ -922,20 +908,18 @@
                                                   } @else {
                                                   <div class="metrique-form-block">
                                                     <div class="metrique-row">
-                                                      <mat-form-field appearance="outline" class="flex-grow">
-                                                        <mat-label>{{ 'enjeux.metriques.nomLabel' | translate }} *</mat-label>
-                                                        <input matInput [(ngModel)]="met.nom_metrique">
-                                                      </mat-form-field>
+                                                      <app-form-field [label]="('enjeux.metriques.nomLabel' | translate) + ' *'">
+  <input [(ngModel)]="met.nom_metrique">
+</app-form-field>
                                                       <button class="icon-btn-flat metrique-delete-btn" (click)="removeMetriqueFromEdit(i)" [title]="'common.actions.delete' | translate">
                                                         <i class="fi fi-rr-trash"></i>
                                                       </button>
                                                     </div>
 
                                                     <div class="metrique-row-2col">
-                                                      <mat-form-field appearance="outline">
-                                                        <mat-label>{{ 'enjeux.metriques.uniteLabel' | translate }}</mat-label>
-                                                        <input matInput [(ngModel)]="met.unite">
-                                                      </mat-form-field>
+                                                      <app-form-field [label]="'enjeux.metriques.uniteLabel' | translate">
+  <input [(ngModel)]="met.unite">
+</app-form-field>
                                                       <mat-form-field appearance="outline">
                                                         <mat-label>{{ 'enjeux.metriques.typeLabel' | translate }}</mat-label>
                                                         <mat-select [(ngModel)]="met.type_metrique">
@@ -947,14 +931,12 @@
                                                     </div>
 
                                                     <div class="metrique-row-2col">
-                                                      <mat-form-field appearance="outline" class="col-narrow">
-                                                        <mat-label>{{ 'enjeux.metriques.ponderationLabel' | translate }}</mat-label>
-                                                        <input matInput type="number" [(ngModel)]="met.ponderation">
-                                                      </mat-form-field>
-                                                      <mat-form-field appearance="outline" class="col-wide">
-                                                        <mat-label>{{ 'enjeux.metriques.etatReferenceLabel' | translate }}</mat-label>
-                                                        <input matInput [(ngModel)]="met.etat_reference">
-                                                      </mat-form-field>
+                                                      <app-form-field [label]="'enjeux.metriques.ponderationLabel' | translate">
+  <input type="number" [(ngModel)]="met.ponderation">
+</app-form-field>
+                                                      <app-form-field [label]="'enjeux.metriques.etatReferenceLabel' | translate">
+  <input [(ngModel)]="met.etat_reference">
+</app-form-field>
                                                     </div>
 
                                                     <!-- Direction selector (NUMERIQUE only) -->
@@ -978,16 +960,14 @@
                                                           <div class="score-column-inputs">
                                                             @switch (getMetriqueTypeMnemonique(met.type_metrique)) {
                                                               @case ('CHIFFRE') {
-                                                                <mat-form-field appearance="outline" class="score-input">
-                                                                  <mat-label>{{ 'enjeux.metriques.valeur' | translate }}</mat-label>
-                                                                  <input matInput type="number" [(ngModel)]="met.scores[level].val">
-                                                                </mat-form-field>
+                                                                <app-form-field [label]="'enjeux.metriques.valeur' | translate">
+  <input type="number" [(ngModel)]="met.scores[level].val">
+</app-form-field>
                                                               }
                                                               @case ('TEXTE') {
-                                                                <mat-form-field appearance="outline" class="score-input">
-                                                                  <mat-label>{{ 'enjeux.metriques.texte' | translate }}</mat-label>
-                                                                  <input matInput [(ngModel)]="met.scores[level].label">
-                                                                </mat-form-field>
+                                                                <app-form-field [label]="'enjeux.metriques.texte' | translate">
+  <input [(ngModel)]="met.scores[level].label">
+</app-form-field>
                                                               }
                                                               @default {
                                                                 <!-- Fixed-height slot for optional bound checkbox -->
@@ -1004,18 +984,16 @@
                                                                   }
                                                                 </div>
                                                                 <div class="score-fields" [class.descending]="met.sens_variation === 'DECROISSANT'">
-                                                                  <mat-form-field appearance="outline" class="score-input">
-                                                                    <mat-label>{{ 'enjeux.metriques.min' | translate }}</mat-label>
-                                                                    <input matInput type="number" [(ngModel)]="met.scores[level].inf"
+                                                                  <app-form-field [label]="'enjeux.metriques.min' | translate">
+  <input type="number" [(ngModel)]="met.scores[level].inf"
                                                                       [disabled]="isScoreFieldDisabled(met, level, 'inf')"
                                                                       (ngModelChange)="onScoreBoundaryChange(met, level, 'inf')">
-                                                                  </mat-form-field>
-                                                                  <mat-form-field appearance="outline" class="score-input">
-                                                                    <mat-label>{{ 'enjeux.metriques.max' | translate }}</mat-label>
-                                                                    <input matInput type="number" [(ngModel)]="met.scores[level].sup"
+</app-form-field>
+                                                                  <app-form-field [label]="'enjeux.metriques.max' | translate">
+  <input type="number" [(ngModel)]="met.scores[level].sup"
                                                                       [disabled]="isScoreFieldDisabled(met, level, 'sup')"
                                                                       (ngModelChange)="onScoreBoundaryChange(met, level, 'sup')">
-                                                                  </mat-form-field>
+</app-form-field>
                                                                 </div>
                                                                 <!-- Fixed-height slot for boundary toggle -->
                                                                 <div class="boundary-toggle-slot">
@@ -1539,16 +1517,14 @@
                                                     </app-metrique-form>
                                                   } @else {
                                                   <div class="metrique-row">
-                                                    <mat-form-field appearance="outline" class="flex-grow">
-                                                      <mat-label>{{ 'enjeux.metriques.nomLabel' | translate }} *</mat-label>
-                                                      <input matInput [(ngModel)]="standaloneMetriqueForm.nom_metrique">
-                                                    </mat-form-field>
+                                                    <app-form-field [label]="('enjeux.metriques.nomLabel' | translate) + ' *'">
+  <input [(ngModel)]="standaloneMetriqueForm.nom_metrique">
+</app-form-field>
                                                   </div>
                                                   <div class="metrique-row-2col">
-                                                    <mat-form-field appearance="outline">
-                                                      <mat-label>{{ 'enjeux.metriques.uniteLabel' | translate }}</mat-label>
-                                                      <input matInput [(ngModel)]="standaloneMetriqueForm.unite">
-                                                    </mat-form-field>
+                                                    <app-form-field [label]="'enjeux.metriques.uniteLabel' | translate">
+  <input [(ngModel)]="standaloneMetriqueForm.unite">
+</app-form-field>
                                                     <mat-form-field appearance="outline">
                                                       <mat-label>{{ 'enjeux.metriques.typeLabel' | translate }}</mat-label>
                                                       <mat-select [(ngModel)]="standaloneMetriqueForm.type_metrique">
@@ -1559,14 +1535,12 @@
                                                     </mat-form-field>
                                                   </div>
                                                   <div class="metrique-row-2col">
-                                                    <mat-form-field appearance="outline" class="col-narrow">
-                                                      <mat-label>{{ 'enjeux.metriques.ponderationLabel' | translate }}</mat-label>
-                                                      <input matInput type="number" [(ngModel)]="standaloneMetriqueForm.ponderation">
-                                                    </mat-form-field>
-                                                    <mat-form-field appearance="outline" class="col-wide">
-                                                      <mat-label>{{ 'enjeux.metriques.etatReferenceLabel' | translate }}</mat-label>
-                                                      <input matInput [(ngModel)]="standaloneMetriqueForm.etat_reference">
-                                                    </mat-form-field>
+                                                    <app-form-field [label]="'enjeux.metriques.ponderationLabel' | translate">
+  <input type="number" [(ngModel)]="standaloneMetriqueForm.ponderation">
+</app-form-field>
+                                                    <app-form-field [label]="'enjeux.metriques.etatReferenceLabel' | translate">
+  <input [(ngModel)]="standaloneMetriqueForm.etat_reference">
+</app-form-field>
                                                   </div>
                                                   <!-- Direction selector (NUMERIQUE only) -->
                                                   @if (getMetriqueTypeMnemonique(standaloneMetriqueForm.type_metrique) === 'NUMERIQUE') {
@@ -1589,16 +1563,14 @@
                                                         <div class="score-column-inputs">
                                                           @switch (getMetriqueTypeMnemonique(standaloneMetriqueForm.type_metrique)) {
                                                             @case ('CHIFFRE') {
-                                                              <mat-form-field appearance="outline" class="score-input">
-                                                                <mat-label>{{ 'enjeux.metriques.valeur' | translate }}</mat-label>
-                                                                <input matInput type="number" [(ngModel)]="standaloneMetriqueForm.scores[level].val">
-                                                              </mat-form-field>
+                                                              <app-form-field [label]="'enjeux.metriques.valeur' | translate">
+  <input type="number" [(ngModel)]="standaloneMetriqueForm.scores[level].val">
+</app-form-field>
                                                             }
                                                             @case ('TEXTE') {
-                                                              <mat-form-field appearance="outline" class="score-input">
-                                                                <mat-label>{{ 'enjeux.metriques.texte' | translate }}</mat-label>
-                                                                <input matInput [(ngModel)]="standaloneMetriqueForm.scores[level].label">
-                                                              </mat-form-field>
+                                                              <app-form-field [label]="'enjeux.metriques.texte' | translate">
+  <input [(ngModel)]="standaloneMetriqueForm.scores[level].label">
+</app-form-field>
                                                             }
                                                             @default {
                                                               <!-- Fixed-height slot for optional bound checkbox -->
@@ -1615,18 +1587,16 @@
                                                                 }
                                                               </div>
                                                               <div class="score-fields" [class.descending]="standaloneMetriqueForm.sens_variation === 'DECROISSANT'">
-                                                                <mat-form-field appearance="outline" class="score-input">
-                                                                  <mat-label>{{ 'enjeux.metriques.min' | translate }}</mat-label>
-                                                                  <input matInput type="number" [(ngModel)]="standaloneMetriqueForm.scores[level].inf"
+                                                                <app-form-field [label]="'enjeux.metriques.min' | translate">
+  <input type="number" [(ngModel)]="standaloneMetriqueForm.scores[level].inf"
                                                                     [disabled]="isScoreFieldDisabled(standaloneMetriqueForm, level, 'inf')"
                                                                     (ngModelChange)="onScoreBoundaryChange(standaloneMetriqueForm, level, 'inf')">
-                                                                </mat-form-field>
-                                                                <mat-form-field appearance="outline" class="score-input">
-                                                                  <mat-label>{{ 'enjeux.metriques.max' | translate }}</mat-label>
-                                                                  <input matInput type="number" [(ngModel)]="standaloneMetriqueForm.scores[level].sup"
+</app-form-field>
+                                                                <app-form-field [label]="'enjeux.metriques.max' | translate">
+  <input type="number" [(ngModel)]="standaloneMetriqueForm.scores[level].sup"
                                                                     [disabled]="isScoreFieldDisabled(standaloneMetriqueForm, level, 'sup')"
                                                                     (ngModelChange)="onScoreBoundaryChange(standaloneMetriqueForm, level, 'sup')">
-                                                                </mat-form-field>
+</app-form-field>
                                                               </div>
                                                               <!-- Fixed-height slot for boundary toggle -->
                                                               <div class="boundary-toggle-slot">
@@ -1676,10 +1646,9 @@
                                         <p class="form-required-note">{{ 'common.requiredFields' | translate }}</p>
 
                                         <!-- Intitulé indicateur -->
-                                        <mat-form-field appearance="outline" class="full-width">
-                                          <mat-label>{{ 'enjeux.indicateurs.nomLabel' | translate }} *</mat-label>
-                                          <input matInput [(ngModel)]="newIndicateurNom">
-                                        </mat-form-field>
+                                        <app-form-field [label]="('enjeux.indicateurs.nomLabel' | translate) + ' *'">
+  <input [(ngModel)]="newIndicateurNom">
+</app-form-field>
 
                                         <!-- Indicateur standardisé -->
                                         <div class="form-radio-row">
@@ -1691,10 +1660,9 @@
                                         </div>
 
                                         <!-- Description -->
-                                        <mat-form-field appearance="outline" class="full-width">
-                                          <mat-label>{{ 'enjeux.indicateurs.descriptionLabel' | translate }}</mat-label>
-                                          <textarea matInput [(ngModel)]="newIndicateurDescription" rows="3"></textarea>
-                                        </mat-form-field>
+                                        <app-form-field [label]="'enjeux.indicateurs.descriptionLabel' | translate">
+  <textarea [(ngModel)]="newIndicateurDescription" rows="3"></textarea>
+</app-form-field>
 
                                         <!-- Section MÉTRIQUES -->
                                         <div class="metriques-section">
@@ -1758,10 +1726,9 @@
                                             <div class="metrique-form-block">
                                               <!-- Row 1: Nom + delete -->
                                               <div class="metrique-row">
-                                                <mat-form-field appearance="outline" class="flex-grow">
-                                                  <mat-label>{{ 'enjeux.metriques.nomLabel' | translate }} *</mat-label>
-                                                  <input matInput [(ngModel)]="met.nom_metrique">
-                                                </mat-form-field>
+                                                <app-form-field [label]="('enjeux.metriques.nomLabel' | translate) + ' *'">
+  <input [(ngModel)]="met.nom_metrique">
+</app-form-field>
                                                 <button class="icon-btn-flat metrique-delete-btn" (click)="removeMetriqueFromForm(i)" [title]="'common.actions.delete' | translate">
                                                   <i class="fi fi-rr-trash"></i>
                                                 </button>
@@ -1769,10 +1736,9 @@
 
                                               <!-- Row 2: Unité + Type -->
                                               <div class="metrique-row-2col">
-                                                <mat-form-field appearance="outline">
-                                                  <mat-label>{{ 'enjeux.metriques.uniteLabel' | translate }}</mat-label>
-                                                  <input matInput [(ngModel)]="met.unite">
-                                                </mat-form-field>
+                                                <app-form-field [label]="'enjeux.metriques.uniteLabel' | translate">
+  <input [(ngModel)]="met.unite">
+</app-form-field>
                                                 <mat-form-field appearance="outline">
                                                   <mat-label>{{ 'enjeux.metriques.typeLabel' | translate }}</mat-label>
                                                   <mat-select [(ngModel)]="met.type_metrique">
@@ -1785,14 +1751,12 @@
 
                                               <!-- Row 3: Pondération + État de référence -->
                                               <div class="metrique-row-2col">
-                                                <mat-form-field appearance="outline" class="col-narrow">
-                                                  <mat-label>{{ 'enjeux.metriques.ponderationLabel' | translate }}</mat-label>
-                                                  <input matInput type="number" [(ngModel)]="met.ponderation">
-                                                </mat-form-field>
-                                                <mat-form-field appearance="outline" class="col-wide">
-                                                  <mat-label>{{ 'enjeux.metriques.etatReferenceLabel' | translate }}</mat-label>
-                                                  <input matInput [(ngModel)]="met.etat_reference">
-                                                </mat-form-field>
+                                                <app-form-field [label]="'enjeux.metriques.ponderationLabel' | translate">
+  <input type="number" [(ngModel)]="met.ponderation">
+</app-form-field>
+                                                <app-form-field [label]="'enjeux.metriques.etatReferenceLabel' | translate">
+  <input [(ngModel)]="met.etat_reference">
+</app-form-field>
                                               </div>
 
                                               <!-- Score threshold grid -->
@@ -1817,16 +1781,14 @@
                                                     <div class="score-column-inputs">
                                                       @switch (getMetriqueTypeMnemonique(met.type_metrique)) {
                                                         @case ('CHIFFRE') {
-                                                          <mat-form-field appearance="outline" class="score-input">
-                                                            <mat-label>{{ 'enjeux.metriques.valeur' | translate }}</mat-label>
-                                                            <input matInput type="number" [(ngModel)]="met.scores[level].val">
-                                                          </mat-form-field>
+                                                          <app-form-field [label]="'enjeux.metriques.valeur' | translate">
+  <input type="number" [(ngModel)]="met.scores[level].val">
+</app-form-field>
                                                         }
                                                         @case ('TEXTE') {
-                                                          <mat-form-field appearance="outline" class="score-input">
-                                                            <mat-label>{{ 'enjeux.metriques.texte' | translate }}</mat-label>
-                                                            <input matInput [(ngModel)]="met.scores[level].label">
-                                                          </mat-form-field>
+                                                          <app-form-field [label]="'enjeux.metriques.texte' | translate">
+  <input [(ngModel)]="met.scores[level].label">
+</app-form-field>
                                                         }
                                                         @default {
                                                           <!-- Fixed-height slot for optional bound checkbox -->
@@ -1843,18 +1805,16 @@
                                                             }
                                                           </div>
                                                           <div class="score-fields" [class.descending]="met.sens_variation === 'DECROISSANT'">
-                                                            <mat-form-field appearance="outline" class="score-input">
-                                                              <mat-label>{{ 'enjeux.metriques.min' | translate }}</mat-label>
-                                                              <input matInput type="number" [(ngModel)]="met.scores[level].inf"
+                                                            <app-form-field [label]="'enjeux.metriques.min' | translate">
+  <input type="number" [(ngModel)]="met.scores[level].inf"
                                                                 [disabled]="isScoreFieldDisabled(met, level, 'inf')"
                                                                 (ngModelChange)="onScoreBoundaryChange(met, level, 'inf')">
-                                                            </mat-form-field>
-                                                            <mat-form-field appearance="outline" class="score-input">
-                                                              <mat-label>{{ 'enjeux.metriques.max' | translate }}</mat-label>
-                                                              <input matInput type="number" [(ngModel)]="met.scores[level].sup"
+</app-form-field>
+                                                            <app-form-field [label]="'enjeux.metriques.max' | translate">
+  <input type="number" [(ngModel)]="met.scores[level].sup"
                                                                 [disabled]="isScoreFieldDisabled(met, level, 'sup')"
                                                                 (ngModelChange)="onScoreBoundaryChange(met, level, 'sup')">
-                                                            </mat-form-field>
+</app-form-field>
                                                           </div>
                                                           <!-- Fixed-height slot for boundary toggle -->
                                                           <div class="boundary-toggle-slot">
@@ -1916,14 +1876,12 @@
                                     <h4 class="inline-form-title">{{ 'enjeux.niveauExigence.newTitle' | translate }}</h4>
                                   </div>
                                   <div class="inline-form-body">
-                                    <mat-form-field class="full-width" appearance="outline">
-                                      <mat-label>{{ 'enjeux.niveauExigence.libelleLabel' | translate }}</mat-label>
-                                      <input matInput [(ngModel)]="newNeLibelle">
-                                    </mat-form-field>
-                                    <mat-form-field class="full-width" appearance="outline">
-                                      <mat-label>{{ 'enjeux.niveauExigence.descriptionLabel' | translate }}</mat-label>
-                                      <textarea matInput [(ngModel)]="newNeDescription" rows="2"></textarea>
-                                    </mat-form-field>
+                                    <app-form-field class="full-width" [label]="'enjeux.niveauExigence.libelleLabel' | translate">
+  <input [(ngModel)]="newNeLibelle">
+</app-form-field>
+                                    <app-form-field class="full-width" [label]="'enjeux.niveauExigence.descriptionLabel' | translate">
+  <textarea [(ngModel)]="newNeDescription" rows="2"></textarea>
+</app-form-field>
                                   </div>
                                   <div class="inline-form-actions">
                                     <button mat-flat-button color="primary" (click)="saveNe(olt)" [disabled]="!newNeLibelle.trim()">
@@ -1954,14 +1912,12 @@
                     <h4 class="inline-form-title">{{ 'enjeux.olt.newTitle' | translate }}</h4>
                   </div>
                   <div class="inline-form-body">
-                    <mat-form-field class="full-width" appearance="outline">
-                      <mat-label>{{ 'enjeux.olt.libelleLabel' | translate }}</mat-label>
-                      <input matInput [(ngModel)]="newOltLibelle">
-                    </mat-form-field>
-                    <mat-form-field class="full-width" appearance="outline">
-                      <mat-label>{{ 'enjeux.olt.descriptionLabel' | translate }}</mat-label>
-                      <textarea matInput [(ngModel)]="newOltDescription" rows="2"></textarea>
-                    </mat-form-field>
+                    <app-form-field class="full-width" [label]="'enjeux.olt.libelleLabel' | translate">
+  <input [(ngModel)]="newOltLibelle">
+</app-form-field>
+                    <app-form-field class="full-width" [label]="'enjeux.olt.descriptionLabel' | translate">
+  <textarea [(ngModel)]="newOltDescription" rows="2"></textarea>
+</app-form-field>
                   </div>
                   <div class="inline-form-actions">
                     <button mat-flat-button color="primary" (click)="saveOlt()" [disabled]="!newOltLibelle.trim()">
@@ -2025,14 +1981,12 @@
                       <h4 class="inline-form-title">{{ 'enjeux.oo.editTitle' | translate }}</h4>
                     </div>
                     <div class="inline-form-body">
-                      <mat-form-field class="full-width" appearance="outline">
-                        <mat-label>{{ 'enjeux.oo.libelleLabel' | translate }}</mat-label>
-                        <input matInput [(ngModel)]="editOoLibelle">
-                      </mat-form-field>
-                      <mat-form-field class="full-width" appearance="outline">
-                        <mat-label>{{ 'enjeux.oo.descriptionLabel' | translate }}</mat-label>
-                        <textarea matInput [(ngModel)]="editOoDescription" rows="2"></textarea>
-                      </mat-form-field>
+                      <app-form-field class="full-width" [label]="'enjeux.oo.libelleLabel' | translate">
+  <input [(ngModel)]="editOoLibelle">
+</app-form-field>
+                      <app-form-field class="full-width" [label]="'enjeux.oo.descriptionLabel' | translate">
+  <textarea [(ngModel)]="editOoDescription" rows="2"></textarea>
+</app-form-field>
                       <mat-form-field class="full-width" appearance="outline">
                         <mat-label>{{ 'enjeux.oo.pressionLabel' | translate }} *</mat-label>
                         <mat-select [(ngModel)]="editOoPressionIds" multiple required>
@@ -2130,14 +2084,12 @@
                         @if (editingRaId() === ra.id_ra) {
                           <div class="inline-form ne-inline-form">
                             <div class="inline-form-body">
-                              <mat-form-field class="full-width" appearance="outline">
-                                <mat-label>{{ 'enjeux.resultatAttendu.libelleLabel' | translate }}</mat-label>
-                                <input matInput [(ngModel)]="editRaLibelle">
-                              </mat-form-field>
-                              <mat-form-field class="full-width" appearance="outline">
-                                <mat-label>{{ 'enjeux.resultatAttendu.descriptionLabel' | translate }}</mat-label>
-                                <textarea matInput [(ngModel)]="editRaDescription" rows="2"></textarea>
-                              </mat-form-field>
+                              <app-form-field class="full-width" [label]="'enjeux.resultatAttendu.libelleLabel' | translate">
+  <input [(ngModel)]="editRaLibelle">
+</app-form-field>
+                              <app-form-field class="full-width" [label]="'enjeux.resultatAttendu.descriptionLabel' | translate">
+  <textarea [(ngModel)]="editRaDescription" rows="2"></textarea>
+</app-form-field>
                             </div>
                             <div class="inline-form-actions">
                               <button mat-flat-button color="primary" (click)="saveEditRa(ra)" [disabled]="!editRaLibelle.trim()">
@@ -2209,10 +2161,9 @@
                                     </div>
 
                                     <!-- Intitulé indicateur -->
-                                    <mat-form-field appearance="outline" class="full-width">
-                                      <mat-label>{{ 'enjeux.indicateurs.nomLabel' | translate }} *</mat-label>
-                                      <input matInput [(ngModel)]="editOoIndicateurNom">
-                                    </mat-form-field>
+                                    <app-form-field [label]="('enjeux.indicateurs.nomLabel' | translate) + ' *'">
+  <input [(ngModel)]="editOoIndicateurNom">
+</app-form-field>
 
                                     <!-- Indicateur standardisé -->
                                     <div class="form-radio-row">
@@ -2224,10 +2175,9 @@
                                     </div>
 
                                     <!-- Description -->
-                                    <mat-form-field appearance="outline" class="full-width">
-                                      <mat-label>{{ 'enjeux.indicateurs.descriptionLabel' | translate }}</mat-label>
-                                      <textarea matInput [(ngModel)]="editOoIndicateurDescription" rows="3"></textarea>
-                                    </mat-form-field>
+                                    <app-form-field [label]="'enjeux.indicateurs.descriptionLabel' | translate">
+  <textarea [(ngModel)]="editOoIndicateurDescription" rows="3"></textarea>
+</app-form-field>
 
                                     <!-- Section MÉTRIQUES -->
                                     <div class="metriques-section">
@@ -2291,20 +2241,18 @@
                                           } @else {
                                           <div class="metrique-form-block">
                                             <div class="metrique-row">
-                                              <mat-form-field appearance="outline" class="flex-grow">
-                                                <mat-label>{{ 'enjeux.metriques.nomLabel' | translate }} *</mat-label>
-                                                <input matInput [(ngModel)]="met.nom_metrique">
-                                              </mat-form-field>
+                                              <app-form-field [label]="('enjeux.metriques.nomLabel' | translate) + ' *'">
+  <input [(ngModel)]="met.nom_metrique">
+</app-form-field>
                                               <button class="icon-btn-flat metrique-delete-btn" (click)="removeOoMetriqueFromEdit(i)" [title]="'common.actions.delete' | translate">
                                                 <i class="fi fi-rr-trash"></i>
                                               </button>
                                             </div>
 
                                             <div class="metrique-row-2col">
-                                              <mat-form-field appearance="outline">
-                                                <mat-label>{{ 'enjeux.metriques.uniteLabel' | translate }}</mat-label>
-                                                <input matInput [(ngModel)]="met.unite">
-                                              </mat-form-field>
+                                              <app-form-field [label]="'enjeux.metriques.uniteLabel' | translate">
+  <input [(ngModel)]="met.unite">
+</app-form-field>
                                               <mat-form-field appearance="outline">
                                                 <mat-label>{{ 'enjeux.metriques.typeLabel' | translate }}</mat-label>
                                                 <mat-select [(ngModel)]="met.type_metrique">
@@ -2316,14 +2264,12 @@
                                             </div>
 
                                             <div class="metrique-row-2col">
-                                              <mat-form-field appearance="outline" class="col-narrow">
-                                                <mat-label>{{ 'enjeux.metriques.ponderationLabel' | translate }}</mat-label>
-                                                <input matInput type="number" [(ngModel)]="met.ponderation">
-                                              </mat-form-field>
-                                              <mat-form-field appearance="outline" class="col-wide">
-                                                <mat-label>{{ 'enjeux.metriques.etatReferenceLabel' | translate }}</mat-label>
-                                                <input matInput [(ngModel)]="met.etat_reference">
-                                              </mat-form-field>
+                                              <app-form-field [label]="'enjeux.metriques.ponderationLabel' | translate">
+  <input type="number" [(ngModel)]="met.ponderation">
+</app-form-field>
+                                              <app-form-field [label]="'enjeux.metriques.etatReferenceLabel' | translate">
+  <input [(ngModel)]="met.etat_reference">
+</app-form-field>
                                             </div>
 
                                             <!-- Direction selector (NUMERIQUE only) -->
@@ -2347,16 +2293,14 @@
                                                   <div class="score-column-inputs">
                                                     @switch (getMetriqueTypeMnemonique(met.type_metrique)) {
                                                       @case ('CHIFFRE') {
-                                                        <mat-form-field appearance="outline" class="score-input">
-                                                          <mat-label>{{ 'enjeux.metriques.valeur' | translate }}</mat-label>
-                                                          <input matInput type="number" [(ngModel)]="met.scores[level].val">
-                                                        </mat-form-field>
+                                                        <app-form-field [label]="'enjeux.metriques.valeur' | translate">
+  <input type="number" [(ngModel)]="met.scores[level].val">
+</app-form-field>
                                                       }
                                                       @case ('TEXTE') {
-                                                        <mat-form-field appearance="outline" class="score-input">
-                                                          <mat-label>{{ 'enjeux.metriques.texte' | translate }}</mat-label>
-                                                          <input matInput [(ngModel)]="met.scores[level].label">
-                                                        </mat-form-field>
+                                                        <app-form-field [label]="'enjeux.metriques.texte' | translate">
+  <input [(ngModel)]="met.scores[level].label">
+</app-form-field>
                                                       }
                                                       @default {
                                                         <!-- Fixed-height slot for optional bound checkbox -->
@@ -2373,18 +2317,16 @@
                                                           }
                                                         </div>
                                                         <div class="score-fields" [class.descending]="met.sens_variation === 'DECROISSANT'">
-                                                          <mat-form-field appearance="outline" class="score-input">
-                                                            <mat-label>{{ 'enjeux.metriques.min' | translate }}</mat-label>
-                                                            <input matInput type="number" [(ngModel)]="met.scores[level].inf"
+                                                          <app-form-field [label]="'enjeux.metriques.min' | translate">
+  <input type="number" [(ngModel)]="met.scores[level].inf"
                                                               [disabled]="isScoreFieldDisabled(met, level, 'inf')"
                                                               (ngModelChange)="onScoreBoundaryChange(met, level, 'inf')">
-                                                          </mat-form-field>
-                                                          <mat-form-field appearance="outline" class="score-input">
-                                                            <mat-label>{{ 'enjeux.metriques.max' | translate }}</mat-label>
-                                                            <input matInput type="number" [(ngModel)]="met.scores[level].sup"
+</app-form-field>
+                                                          <app-form-field [label]="'enjeux.metriques.max' | translate">
+  <input type="number" [(ngModel)]="met.scores[level].sup"
                                                               [disabled]="isScoreFieldDisabled(met, level, 'sup')"
                                                               (ngModelChange)="onScoreBoundaryChange(met, level, 'sup')">
-                                                          </mat-form-field>
+</app-form-field>
                                                         </div>
                                                         <!-- Fixed-height slot for boundary toggle -->
                                                         <div class="boundary-toggle-slot">
@@ -2888,16 +2830,14 @@
                                         <div class="metrique-form-block standalone-metrique-form">
                                           <h5 class="metriques-section-title">{{ 'enjeux.metriques.addButton' | translate }}</h5>
                                           <div class="metrique-row">
-                                            <mat-form-field appearance="outline" class="flex-grow">
-                                              <mat-label>{{ 'enjeux.metriques.nomLabel' | translate }} *</mat-label>
-                                              <input matInput [(ngModel)]="standaloneMetriqueForm.nom_metrique">
-                                            </mat-form-field>
+                                            <app-form-field [label]="('enjeux.metriques.nomLabel' | translate) + ' *'">
+  <input [(ngModel)]="standaloneMetriqueForm.nom_metrique">
+</app-form-field>
                                           </div>
                                           <div class="metrique-row-2col">
-                                            <mat-form-field appearance="outline">
-                                              <mat-label>{{ 'enjeux.metriques.uniteLabel' | translate }}</mat-label>
-                                              <input matInput [(ngModel)]="standaloneMetriqueForm.unite">
-                                            </mat-form-field>
+                                            <app-form-field [label]="'enjeux.metriques.uniteLabel' | translate">
+  <input [(ngModel)]="standaloneMetriqueForm.unite">
+</app-form-field>
                                             <mat-form-field appearance="outline">
                                               <mat-label>{{ 'enjeux.metriques.typeLabel' | translate }}</mat-label>
                                               <mat-select [(ngModel)]="standaloneMetriqueForm.type_metrique">
@@ -2908,14 +2848,12 @@
                                             </mat-form-field>
                                           </div>
                                           <div class="metrique-row-2col">
-                                            <mat-form-field appearance="outline" class="col-narrow">
-                                              <mat-label>{{ 'enjeux.metriques.ponderationLabel' | translate }}</mat-label>
-                                              <input matInput type="number" [(ngModel)]="standaloneMetriqueForm.ponderation">
-                                            </mat-form-field>
-                                            <mat-form-field appearance="outline" class="col-wide">
-                                              <mat-label>{{ 'enjeux.metriques.etatReferenceLabel' | translate }}</mat-label>
-                                              <input matInput [(ngModel)]="standaloneMetriqueForm.etat_reference">
-                                            </mat-form-field>
+                                            <app-form-field [label]="'enjeux.metriques.ponderationLabel' | translate">
+  <input type="number" [(ngModel)]="standaloneMetriqueForm.ponderation">
+</app-form-field>
+                                            <app-form-field [label]="'enjeux.metriques.etatReferenceLabel' | translate">
+  <input [(ngModel)]="standaloneMetriqueForm.etat_reference">
+</app-form-field>
                                           </div>
                                           <!-- Direction selector (NUMERIQUE only) -->
                                           @if (getMetriqueTypeMnemonique(standaloneMetriqueForm.type_metrique) === 'NUMERIQUE') {
@@ -2938,16 +2876,14 @@
                                                 <div class="score-column-inputs">
                                                   @switch (getMetriqueTypeMnemonique(standaloneMetriqueForm.type_metrique)) {
                                                     @case ('CHIFFRE') {
-                                                      <mat-form-field appearance="outline" class="score-input">
-                                                        <mat-label>{{ 'enjeux.metriques.valeur' | translate }}</mat-label>
-                                                        <input matInput type="number" [(ngModel)]="standaloneMetriqueForm.scores[level].val">
-                                                      </mat-form-field>
+                                                      <app-form-field [label]="'enjeux.metriques.valeur' | translate">
+  <input type="number" [(ngModel)]="standaloneMetriqueForm.scores[level].val">
+</app-form-field>
                                                     }
                                                     @case ('TEXTE') {
-                                                      <mat-form-field appearance="outline" class="score-input">
-                                                        <mat-label>{{ 'enjeux.metriques.texte' | translate }}</mat-label>
-                                                        <input matInput [(ngModel)]="standaloneMetriqueForm.scores[level].label">
-                                                      </mat-form-field>
+                                                      <app-form-field [label]="'enjeux.metriques.texte' | translate">
+  <input [(ngModel)]="standaloneMetriqueForm.scores[level].label">
+</app-form-field>
                                                     }
                                                     @default {
                                                       <!-- Fixed-height slot for optional bound checkbox -->
@@ -2964,18 +2900,16 @@
                                                         }
                                                       </div>
                                                       <div class="score-fields" [class.descending]="standaloneMetriqueForm.sens_variation === 'DECROISSANT'">
-                                                        <mat-form-field appearance="outline" class="score-input">
-                                                          <mat-label>{{ 'enjeux.metriques.min' | translate }}</mat-label>
-                                                          <input matInput type="number" [(ngModel)]="standaloneMetriqueForm.scores[level].inf"
+                                                        <app-form-field [label]="'enjeux.metriques.min' | translate">
+  <input type="number" [(ngModel)]="standaloneMetriqueForm.scores[level].inf"
                                                             [disabled]="isScoreFieldDisabled(standaloneMetriqueForm, level, 'inf')"
                                                             (ngModelChange)="onScoreBoundaryChange(standaloneMetriqueForm, level, 'inf')">
-                                                        </mat-form-field>
-                                                        <mat-form-field appearance="outline" class="score-input">
-                                                          <mat-label>{{ 'enjeux.metriques.max' | translate }}</mat-label>
-                                                          <input matInput type="number" [(ngModel)]="standaloneMetriqueForm.scores[level].sup"
+</app-form-field>
+                                                        <app-form-field [label]="'enjeux.metriques.max' | translate">
+  <input type="number" [(ngModel)]="standaloneMetriqueForm.scores[level].sup"
                                                             [disabled]="isScoreFieldDisabled(standaloneMetriqueForm, level, 'sup')"
                                                             (ngModelChange)="onScoreBoundaryChange(standaloneMetriqueForm, level, 'sup')">
-                                                        </mat-form-field>
+</app-form-field>
                                                       </div>
                                                       <!-- Fixed-height slot for boundary toggle -->
                                                       <div class="boundary-toggle-slot">
@@ -3022,10 +2956,9 @@
                                 </div>
                                 <p class="form-required-note">{{ 'common.requiredFields' | translate }}</p>
 
-                                <mat-form-field appearance="outline" class="full-width">
-                                  <mat-label>{{ 'enjeux.indicateurs.nomLabel' | translate }} *</mat-label>
-                                  <input matInput [(ngModel)]="newOoIndicateurNom">
-                                </mat-form-field>
+                                <app-form-field [label]="('enjeux.indicateurs.nomLabel' | translate) + ' *'">
+  <input [(ngModel)]="newOoIndicateurNom">
+</app-form-field>
 
                                 <div class="form-radio-row">
                                   <span class="form-radio-label">{{ 'enjeux.indicateurs.standardiseLabel' | translate }} :</span>
@@ -3036,10 +2969,9 @@
                                 </div>
 
                                 <!-- Description -->
-                                <mat-form-field appearance="outline" class="full-width">
-                                  <mat-label>{{ 'enjeux.indicateurs.descriptionLabel' | translate }}</mat-label>
-                                  <textarea matInput [(ngModel)]="newOoIndicateurDescription" rows="3"></textarea>
-                                </mat-form-field>
+                                <app-form-field [label]="'enjeux.indicateurs.descriptionLabel' | translate">
+  <textarea [(ngModel)]="newOoIndicateurDescription" rows="3"></textarea>
+</app-form-field>
 
                                 <!-- Section MÉTRIQUES -->
                                 <div class="metriques-section">
@@ -3102,20 +3034,18 @@
                                     } @else {
                                     <div class="metrique-form-block">
                                       <div class="metrique-row">
-                                        <mat-form-field appearance="outline" class="flex-grow">
-                                          <mat-label>{{ 'enjeux.metriques.nomLabel' | translate }} *</mat-label>
-                                          <input matInput [(ngModel)]="met.nom_metrique">
-                                        </mat-form-field>
+                                        <app-form-field [label]="('enjeux.metriques.nomLabel' | translate) + ' *'">
+  <input [(ngModel)]="met.nom_metrique">
+</app-form-field>
                                         <button class="icon-btn-flat metrique-delete-btn" (click)="removeOoMetriqueRow(i)" [title]="'common.actions.delete' | translate">
                                           <i class="fi fi-rr-trash"></i>
                                         </button>
                                       </div>
 
                                       <div class="metrique-row-2col">
-                                        <mat-form-field appearance="outline">
-                                          <mat-label>{{ 'enjeux.metriques.uniteLabel' | translate }}</mat-label>
-                                          <input matInput [(ngModel)]="met.unite">
-                                        </mat-form-field>
+                                        <app-form-field [label]="'enjeux.metriques.uniteLabel' | translate">
+  <input [(ngModel)]="met.unite">
+</app-form-field>
                                         <mat-form-field appearance="outline">
                                           <mat-label>{{ 'enjeux.metriques.typeLabel' | translate }}</mat-label>
                                           <mat-select [(ngModel)]="met.type_metrique">
@@ -3127,14 +3057,12 @@
                                       </div>
 
                                       <div class="metrique-row-2col">
-                                        <mat-form-field appearance="outline" class="col-narrow">
-                                          <mat-label>{{ 'enjeux.metriques.ponderationLabel' | translate }}</mat-label>
-                                          <input matInput type="number" [(ngModel)]="met.ponderation">
-                                        </mat-form-field>
-                                        <mat-form-field appearance="outline" class="col-wide">
-                                          <mat-label>{{ 'enjeux.metriques.etatReferenceLabel' | translate }}</mat-label>
-                                          <input matInput [(ngModel)]="met.etat_reference">
-                                        </mat-form-field>
+                                        <app-form-field [label]="'enjeux.metriques.ponderationLabel' | translate">
+  <input type="number" [(ngModel)]="met.ponderation">
+</app-form-field>
+                                        <app-form-field [label]="'enjeux.metriques.etatReferenceLabel' | translate">
+  <input [(ngModel)]="met.etat_reference">
+</app-form-field>
                                       </div>
 
                                       <!-- Direction selector (NUMERIQUE only) -->
@@ -3158,16 +3086,14 @@
                                             <div class="score-column-inputs">
                                               @switch (getMetriqueTypeMnemonique(met.type_metrique)) {
                                                 @case ('CHIFFRE') {
-                                                  <mat-form-field appearance="outline" class="score-input">
-                                                    <mat-label>{{ 'enjeux.metriques.valeur' | translate }}</mat-label>
-                                                    <input matInput type="number" [(ngModel)]="met.scores[level].val">
-                                                  </mat-form-field>
+                                                  <app-form-field [label]="'enjeux.metriques.valeur' | translate">
+  <input type="number" [(ngModel)]="met.scores[level].val">
+</app-form-field>
                                                 }
                                                 @case ('TEXTE') {
-                                                  <mat-form-field appearance="outline" class="score-input">
-                                                    <mat-label>{{ 'enjeux.metriques.texte' | translate }}</mat-label>
-                                                    <input matInput [(ngModel)]="met.scores[level].label">
-                                                  </mat-form-field>
+                                                  <app-form-field [label]="'enjeux.metriques.texte' | translate">
+  <input [(ngModel)]="met.scores[level].label">
+</app-form-field>
                                                 }
                                                 @default {
                                                   <!-- Fixed-height slot for optional bound checkbox -->
@@ -3184,18 +3110,16 @@
                                                     }
                                                   </div>
                                                   <div class="score-fields" [class.descending]="met.sens_variation === 'DECROISSANT'">
-                                                    <mat-form-field appearance="outline" class="score-input">
-                                                      <mat-label>{{ 'enjeux.metriques.min' | translate }}</mat-label>
-                                                      <input matInput type="number" [(ngModel)]="met.scores[level].inf"
+                                                    <app-form-field [label]="'enjeux.metriques.min' | translate">
+  <input type="number" [(ngModel)]="met.scores[level].inf"
                                                         [disabled]="isScoreFieldDisabled(met, level, 'inf')"
                                                         (ngModelChange)="onScoreBoundaryChange(met, level, 'inf')">
-                                                    </mat-form-field>
-                                                    <mat-form-field appearance="outline" class="score-input">
-                                                      <mat-label>{{ 'enjeux.metriques.max' | translate }}</mat-label>
-                                                      <input matInput type="number" [(ngModel)]="met.scores[level].sup"
+</app-form-field>
+                                                    <app-form-field [label]="'enjeux.metriques.max' | translate">
+  <input type="number" [(ngModel)]="met.scores[level].sup"
                                                         [disabled]="isScoreFieldDisabled(met, level, 'sup')"
                                                         (ngModelChange)="onScoreBoundaryChange(met, level, 'sup')">
-                                                    </mat-form-field>
+</app-form-field>
                                                   </div>
                                                   <!-- Fixed-height slot for boundary toggle -->
                                                   <div class="boundary-toggle-slot">
@@ -3255,14 +3179,12 @@
                             <h4 class="inline-form-title">{{ 'enjeux.resultatAttendu.newTitle' | translate }}</h4>
                           </div>
                           <div class="inline-form-body">
-                            <mat-form-field class="full-width" appearance="outline">
-                              <mat-label>{{ 'enjeux.resultatAttendu.libelleLabel' | translate }}</mat-label>
-                              <input matInput [(ngModel)]="newRaLibelle">
-                            </mat-form-field>
-                            <mat-form-field class="full-width" appearance="outline">
-                              <mat-label>{{ 'enjeux.resultatAttendu.descriptionLabel' | translate }}</mat-label>
-                              <textarea matInput [(ngModel)]="newRaDescription" rows="2"></textarea>
-                            </mat-form-field>
+                            <app-form-field class="full-width" [label]="'enjeux.resultatAttendu.libelleLabel' | translate">
+  <input [(ngModel)]="newRaLibelle">
+</app-form-field>
+                            <app-form-field class="full-width" [label]="'enjeux.resultatAttendu.descriptionLabel' | translate">
+  <textarea [(ngModel)]="newRaDescription" rows="2"></textarea>
+</app-form-field>
                           </div>
                           <div class="inline-form-actions">
                             <button mat-flat-button color="primary" (click)="saveRa(oo)" [disabled]="!newRaLibelle.trim()">
@@ -3293,14 +3215,12 @@
                     <h4 class="inline-form-title">{{ 'enjeux.oo.newTitle' | translate }}</h4>
                   </div>
                   <div class="inline-form-body">
-                    <mat-form-field class="full-width" appearance="outline">
-                      <mat-label>{{ 'enjeux.oo.libelleLabel' | translate }}</mat-label>
-                      <input matInput [(ngModel)]="newOoLibelle">
-                    </mat-form-field>
-                    <mat-form-field class="full-width" appearance="outline">
-                      <mat-label>{{ 'enjeux.oo.descriptionLabel' | translate }}</mat-label>
-                      <textarea matInput [(ngModel)]="newOoDescription" rows="2"></textarea>
-                    </mat-form-field>
+                    <app-form-field class="full-width" [label]="'enjeux.oo.libelleLabel' | translate">
+  <input [(ngModel)]="newOoLibelle">
+</app-form-field>
+                    <app-form-field class="full-width" [label]="'enjeux.oo.descriptionLabel' | translate">
+  <textarea [(ngModel)]="newOoDescription" rows="2"></textarea>
+</app-form-field>
                     <mat-form-field class="full-width" appearance="outline">
                       <mat-label>{{ 'enjeux.oo.pressionLabel' | translate }} *</mat-label>
                       <mat-select [(ngModel)]="newOoPressionIds" multiple required>

--- a/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.html
+++ b/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.html
@@ -993,18 +993,14 @@
                                                                 <!-- Fixed-height slot for optional bound checkbox -->
                                                                 <div class="optional-bound-slot">
                                                                   @if (isOptionalBound(met, level, met.sens_variation === 'CROISSANT' ? 'inf' : 'sup') && level === 1) {
-                                                                    <mat-checkbox [(ngModel)]="met.has_score1_optional_bound"
+                                                                    <app-checkbox [(ngModel)]="met.has_score1_optional_bound"
                                                                       (ngModelChange)="onOptionalBoundToggle(met, 1)"
-                                                                      class="optional-bound-checkbox">
-                                                                      {{ getOptionalBoundLabel(met, 1) }}
-                                                                    </mat-checkbox>
+                                                                      class="optional-bound-checkbox" [label]="getOptionalBoundLabel(met, 1)"></app-checkbox>
                                                                   }
                                                                   @if (isOptionalBound(met, level, met.sens_variation === 'CROISSANT' ? 'sup' : 'inf') && level === 5) {
-                                                                    <mat-checkbox [(ngModel)]="met.has_score5_optional_bound"
+                                                                    <app-checkbox [(ngModel)]="met.has_score5_optional_bound"
                                                                       (ngModelChange)="onOptionalBoundToggle(met, 5)"
-                                                                      class="optional-bound-checkbox">
-                                                                      {{ getOptionalBoundLabel(met, 5) }}
-                                                                    </mat-checkbox>
+                                                                      class="optional-bound-checkbox" [label]="getOptionalBoundLabel(met, 5)"></app-checkbox>
                                                                   }
                                                                 </div>
                                                                 <div class="score-fields" [class.descending]="met.sens_variation === 'DECROISSANT'">
@@ -1608,18 +1604,14 @@
                                                               <!-- Fixed-height slot for optional bound checkbox -->
                                                               <div class="optional-bound-slot">
                                                                 @if (isOptionalBound(standaloneMetriqueForm, level, standaloneMetriqueForm.sens_variation === 'CROISSANT' ? 'inf' : 'sup') && level === 1) {
-                                                                  <mat-checkbox [(ngModel)]="standaloneMetriqueForm.has_score1_optional_bound"
+                                                                  <app-checkbox [(ngModel)]="standaloneMetriqueForm.has_score1_optional_bound"
                                                                     (ngModelChange)="onOptionalBoundToggle(standaloneMetriqueForm, 1)"
-                                                                    class="optional-bound-checkbox">
-                                                                    {{ getOptionalBoundLabel(standaloneMetriqueForm, 1) }}
-                                                                  </mat-checkbox>
+                                                                    class="optional-bound-checkbox" [label]="getOptionalBoundLabel(standaloneMetriqueForm, 1)"></app-checkbox>
                                                                 }
                                                                 @if (isOptionalBound(standaloneMetriqueForm, level, standaloneMetriqueForm.sens_variation === 'CROISSANT' ? 'sup' : 'inf') && level === 5) {
-                                                                  <mat-checkbox [(ngModel)]="standaloneMetriqueForm.has_score5_optional_bound"
+                                                                  <app-checkbox [(ngModel)]="standaloneMetriqueForm.has_score5_optional_bound"
                                                                     (ngModelChange)="onOptionalBoundToggle(standaloneMetriqueForm, 5)"
-                                                                    class="optional-bound-checkbox">
-                                                                    {{ getOptionalBoundLabel(standaloneMetriqueForm, 5) }}
-                                                                  </mat-checkbox>
+                                                                    class="optional-bound-checkbox" [label]="getOptionalBoundLabel(standaloneMetriqueForm, 5)"></app-checkbox>
                                                                 }
                                                               </div>
                                                               <div class="score-fields" [class.descending]="standaloneMetriqueForm.sens_variation === 'DECROISSANT'">
@@ -1840,18 +1832,14 @@
                                                           <!-- Fixed-height slot for optional bound checkbox -->
                                                           <div class="optional-bound-slot">
                                                             @if (isOptionalBound(met, level, met.sens_variation === 'CROISSANT' ? 'inf' : 'sup') && level === 1) {
-                                                              <mat-checkbox [(ngModel)]="met.has_score1_optional_bound"
+                                                              <app-checkbox [(ngModel)]="met.has_score1_optional_bound"
                                                                 (ngModelChange)="onOptionalBoundToggle(met, 1)"
-                                                                class="optional-bound-checkbox">
-                                                                {{ getOptionalBoundLabel(met, 1) }}
-                                                              </mat-checkbox>
+                                                                class="optional-bound-checkbox" [label]="getOptionalBoundLabel(met, 1)"></app-checkbox>
                                                             }
                                                             @if (isOptionalBound(met, level, met.sens_variation === 'CROISSANT' ? 'sup' : 'inf') && level === 5) {
-                                                              <mat-checkbox [(ngModel)]="met.has_score5_optional_bound"
+                                                              <app-checkbox [(ngModel)]="met.has_score5_optional_bound"
                                                                 (ngModelChange)="onOptionalBoundToggle(met, 5)"
-                                                                class="optional-bound-checkbox">
-                                                                {{ getOptionalBoundLabel(met, 5) }}
-                                                              </mat-checkbox>
+                                                                class="optional-bound-checkbox" [label]="getOptionalBoundLabel(met, 5)"></app-checkbox>
                                                             }
                                                           </div>
                                                           <div class="score-fields" [class.descending]="met.sens_variation === 'DECROISSANT'">
@@ -2374,18 +2362,14 @@
                                                         <!-- Fixed-height slot for optional bound checkbox -->
                                                         <div class="optional-bound-slot">
                                                           @if (isOptionalBound(met, level, met.sens_variation === 'CROISSANT' ? 'inf' : 'sup') && level === 1) {
-                                                            <mat-checkbox [(ngModel)]="met.has_score1_optional_bound"
+                                                            <app-checkbox [(ngModel)]="met.has_score1_optional_bound"
                                                               (ngModelChange)="onOptionalBoundToggle(met, 1)"
-                                                              class="optional-bound-checkbox">
-                                                              {{ getOptionalBoundLabel(met, 1) }}
-                                                            </mat-checkbox>
+                                                              class="optional-bound-checkbox" [label]="getOptionalBoundLabel(met, 1)"></app-checkbox>
                                                           }
                                                           @if (isOptionalBound(met, level, met.sens_variation === 'CROISSANT' ? 'sup' : 'inf') && level === 5) {
-                                                            <mat-checkbox [(ngModel)]="met.has_score5_optional_bound"
+                                                            <app-checkbox [(ngModel)]="met.has_score5_optional_bound"
                                                               (ngModelChange)="onOptionalBoundToggle(met, 5)"
-                                                              class="optional-bound-checkbox">
-                                                              {{ getOptionalBoundLabel(met, 5) }}
-                                                            </mat-checkbox>
+                                                              class="optional-bound-checkbox" [label]="getOptionalBoundLabel(met, 5)"></app-checkbox>
                                                           }
                                                         </div>
                                                         <div class="score-fields" [class.descending]="met.sens_variation === 'DECROISSANT'">
@@ -2969,18 +2953,14 @@
                                                       <!-- Fixed-height slot for optional bound checkbox -->
                                                       <div class="optional-bound-slot">
                                                         @if (isOptionalBound(standaloneMetriqueForm, level, standaloneMetriqueForm.sens_variation === 'CROISSANT' ? 'inf' : 'sup') && level === 1) {
-                                                          <mat-checkbox [(ngModel)]="standaloneMetriqueForm.has_score1_optional_bound"
+                                                          <app-checkbox [(ngModel)]="standaloneMetriqueForm.has_score1_optional_bound"
                                                             (ngModelChange)="onOptionalBoundToggle(standaloneMetriqueForm, 1)"
-                                                            class="optional-bound-checkbox">
-                                                            {{ getOptionalBoundLabel(standaloneMetriqueForm, 1) }}
-                                                          </mat-checkbox>
+                                                            class="optional-bound-checkbox" [label]="getOptionalBoundLabel(standaloneMetriqueForm, 1)"></app-checkbox>
                                                         }
                                                         @if (isOptionalBound(standaloneMetriqueForm, level, standaloneMetriqueForm.sens_variation === 'CROISSANT' ? 'sup' : 'inf') && level === 5) {
-                                                          <mat-checkbox [(ngModel)]="standaloneMetriqueForm.has_score5_optional_bound"
+                                                          <app-checkbox [(ngModel)]="standaloneMetriqueForm.has_score5_optional_bound"
                                                             (ngModelChange)="onOptionalBoundToggle(standaloneMetriqueForm, 5)"
-                                                            class="optional-bound-checkbox">
-                                                            {{ getOptionalBoundLabel(standaloneMetriqueForm, 5) }}
-                                                          </mat-checkbox>
+                                                            class="optional-bound-checkbox" [label]="getOptionalBoundLabel(standaloneMetriqueForm, 5)"></app-checkbox>
                                                         }
                                                       </div>
                                                       <div class="score-fields" [class.descending]="standaloneMetriqueForm.sens_variation === 'DECROISSANT'">
@@ -3193,18 +3173,14 @@
                                                   <!-- Fixed-height slot for optional bound checkbox -->
                                                   <div class="optional-bound-slot">
                                                     @if (isOptionalBound(met, level, met.sens_variation === 'CROISSANT' ? 'inf' : 'sup') && level === 1) {
-                                                      <mat-checkbox [(ngModel)]="met.has_score1_optional_bound"
+                                                      <app-checkbox [(ngModel)]="met.has_score1_optional_bound"
                                                         (ngModelChange)="onOptionalBoundToggle(met, 1)"
-                                                        class="optional-bound-checkbox">
-                                                        {{ getOptionalBoundLabel(met, 1) }}
-                                                      </mat-checkbox>
+                                                        class="optional-bound-checkbox" [label]="getOptionalBoundLabel(met, 1)"></app-checkbox>
                                                     }
                                                     @if (isOptionalBound(met, level, met.sens_variation === 'CROISSANT' ? 'sup' : 'inf') && level === 5) {
-                                                      <mat-checkbox [(ngModel)]="met.has_score5_optional_bound"
+                                                      <app-checkbox [(ngModel)]="met.has_score5_optional_bound"
                                                         (ngModelChange)="onOptionalBoundToggle(met, 5)"
-                                                        class="optional-bound-checkbox">
-                                                        {{ getOptionalBoundLabel(met, 5) }}
-                                                      </mat-checkbox>
+                                                        class="optional-bound-checkbox" [label]="getOptionalBoundLabel(met, 5)"></app-checkbox>
                                                     }
                                                   </div>
                                                   <div class="score-fields" [class.descending]="met.sens_variation === 'DECROISSANT'">

--- a/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.ts
+++ b/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.ts
@@ -19,7 +19,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatRadioModule } from '@angular/material/radio';
-import { MatCheckboxModule } from '@angular/material/checkbox';
+import { CheckboxComponent } from '../../../../shared/components/checkbox/checkbox.component';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
@@ -79,7 +79,7 @@ type TabType = 'detail' | 'olt' | 'operations';
     MatInputModule,
     MatSelectModule,
     MatRadioModule,
-    MatCheckboxModule,
+    CheckboxComponent,
     MatButtonToggleModule,
     MatTooltipModule,
     MatDialogModule,

--- a/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.ts
+++ b/frontend/src/app/features/plans/enjeux/enjeux-list/enjeux-list.component.ts
@@ -20,6 +20,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatRadioModule } from '@angular/material/radio';
 import { CheckboxComponent } from '../../../../shared/components/checkbox/checkbox.component';
+import { FormFieldComponent } from '../../../../shared/components/form-field/form-field.component';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
@@ -80,6 +81,7 @@ type TabType = 'detail' | 'olt' | 'operations';
     MatSelectModule,
     MatRadioModule,
     CheckboxComponent,
+    FormFieldComponent,
     MatButtonToggleModule,
     MatTooltipModule,
     MatDialogModule,

--- a/frontend/src/app/features/plans/enjeux/fcr-form/fcr-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/fcr-form/fcr-form.component.html
@@ -32,20 +32,19 @@
           <!-- Required fields notice -->
           <p class="required-notice">{{ 'enjeux.fcrForm.requiredBefore' | translate }} <span class="required-star">*</span> {{ 'enjeux.fcrForm.requiredAfter' | translate }}</p>
           <!-- Intitulé -->
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'enjeux.fcrForm.libelle' | translate }} <span class="required-star">*</span></mat-label>
-            <textarea matInput
+          <app-form-field [label]="'enjeux.fcrForm.libelle' | translate" [required]="true">
+  <textarea
                       formControlName="libelle"
                       rows="3"
                       [placeholder]="'enjeux.fcrForm.libellePlaceholder' | translate">
             </textarea>
             @if (form.get('libelle')?.hasError('required') && form.get('libelle')?.touched) {
-              <mat-error>{{ 'common.validation.required' | translate }}</mat-error>
+              
             }
             @if (form.get('libelle')?.hasError('maxlength')) {
-              <mat-error>{{ 'common.validation.maxLength' | translate:{ max: 500 } }}</mat-error>
+              
             }
-          </mat-form-field>
+</app-form-field>
 
           <!-- Intitulé court -->
           <mat-form-field appearance="outline" class="full-width">

--- a/frontend/src/app/features/plans/enjeux/fcr-form/fcr-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/fcr-form/fcr-form.component.html
@@ -78,15 +78,9 @@
           </div>
         </div>
 
-        <!-- Section Détails (accordéon) -->
-        <mat-expansion-panel class="details-panel" hideToggle>
-          <mat-expansion-panel-header>
-            <mat-panel-title>
-              <img src="assets/images/ellipses/ellipse-terra-cotta.png" alt="" class="panel-ellipse">
-              <span class="panel-title-text">{{ 'enjeux.fcrForm.details' | translate }}</span>
-              <i class="fi fi-rr-menu-burger panel-toggle-icon"></i>
-            </mat-panel-title>
-          </mat-expansion-panel-header>
+        <!-- Section Détails (#303 accordion fcr) -->
+        <app-accordion variant="fcr" [title]="'enjeux.fcrForm.details' | translate">
+          <img accordionIcon src="assets/images/ellipses/ellipse-terra-cotta.png" alt="" class="panel-ellipse">
 
           <div class="panel-content">
             <!-- Commentaires -->
@@ -99,7 +93,7 @@
               </textarea>
             </mat-form-field>
           </div>
-        </mat-expansion-panel>
+        </app-accordion>
 
       </form>
     </div>

--- a/frontend/src/app/features/plans/enjeux/fcr-form/fcr-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/fcr-form/fcr-form.component.html
@@ -47,19 +47,19 @@
 </app-form-field>
 
           <!-- Intitulé court -->
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'enjeux.fcrForm.intituleCourt' | translate }} <span class="required-star">*</span></mat-label>
-            <input matInput
-                   formControlName="intitule_court"
+          <app-form-field class="full-width"
+                          [label]="'enjeux.fcrForm.intituleCourt' | translate"
+                          [required]="true"
+                          [helpText]="intituleCourtLength + '/25'">
+            <input formControlName="intitule_court"
                    maxlength="25"
                    [placeholder]="'enjeux.fcrForm.intituleCourtPlaceholder' | translate">
-            <mat-hint align="end">{{ intituleCourtLength }}/25</mat-hint>
-            <button mat-icon-button matSuffix type="button"
+            <button suffixSlot type="button"
                     [matTooltip]="'enjeux.fcrForm.intituleCourtHint' | translate"
                     matTooltipPosition="above">
               <i class="fi fi-rr-interrogation"></i>
             </button>
-          </mat-form-field>
+          </app-form-field>
 
           <!-- Catégorie FCR -->
           <div class="form-group">

--- a/frontend/src/app/features/plans/enjeux/fcr-form/fcr-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/fcr-form/fcr-form.component.html
@@ -84,14 +84,13 @@
 
           <div class="panel-content">
             <!-- Commentaires -->
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'enjeux.fcrForm.commentaires' | translate }}</mat-label>
-              <textarea matInput
+            <app-form-field [label]="'enjeux.fcrForm.commentaires' | translate">
+  <textarea
                         formControlName="description"
                         rows="4"
                         [placeholder]="'enjeux.fcrForm.commentairesPlaceholder' | translate">
               </textarea>
-            </mat-form-field>
+</app-form-field>
           </div>
         </app-accordion>
 

--- a/frontend/src/app/features/plans/enjeux/fcr-form/fcr-form.component.ts
+++ b/frontend/src/app/features/plans/enjeux/fcr-form/fcr-form.component.ts
@@ -20,6 +20,7 @@ import { AccordionComponent } from '../../../../shared/components/accordion/acco
 import { EnjeuService } from '../../../../core/services/enjeu.service';
 import { AdminService } from '../../../../core/services/admin.service';
 import { Enjeu, FcrCreatePayload, EnjeuUpdatePayload } from '../../../../core/models/enjeu.model';
+import { FormFieldComponent } from '../../../../shared/components/form-field/form-field.component';
 
 interface FcrCategorieOption {
   id: number;
@@ -43,7 +44,8 @@ interface FcrCategorieOption {
     MatTooltipModule,
     MatSnackBarModule,
     TranslateModule,
-    HeaderComponent
+    HeaderComponent,
+    FormFieldComponent,
   ],
   templateUrl: './fcr-form.component.html',
   styleUrl: './fcr-form.component.scss'

--- a/frontend/src/app/features/plans/enjeux/fcr-form/fcr-form.component.ts
+++ b/frontend/src/app/features/plans/enjeux/fcr-form/fcr-form.component.ts
@@ -314,7 +314,7 @@ export class FcrFormComponent implements OnInit {
         banner.scrollIntoView({ behavior: 'smooth', block: 'center' });
         return;
       }
-      const invalid = this.elRef.nativeElement.querySelector('mat-form-field.ng-invalid');
+      const invalid = this.elRef.nativeElement.querySelector('input.ng-invalid, textarea.ng-invalid, mat-form-field.ng-invalid');
       invalid?.scrollIntoView({ behavior: 'smooth', block: 'center' });
     });
   }

--- a/frontend/src/app/features/plans/enjeux/fcr-form/fcr-form.component.ts
+++ b/frontend/src/app/features/plans/enjeux/fcr-form/fcr-form.component.ts
@@ -11,12 +11,12 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatExpansionModule } from '@angular/material/expansion';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 import { HeaderComponent } from '../../../../shared/components/header/header.component';
+import { AccordionComponent } from '../../../../shared/components/accordion/accordion.component';
 import { EnjeuService } from '../../../../core/services/enjeu.service';
 import { AdminService } from '../../../../core/services/admin.service';
 import { Enjeu, FcrCreatePayload, EnjeuUpdatePayload } from '../../../../core/models/enjeu.model';
@@ -39,7 +39,7 @@ interface FcrCategorieOption {
     MatButtonModule,
     MatRadioModule,
     MatProgressSpinnerModule,
-    MatExpansionModule,
+    AccordionComponent,
     MatTooltipModule,
     MatSnackBarModule,
     TranslateModule,

--- a/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.html
@@ -458,7 +458,7 @@
                     <button type="button" class="freq-btn" (click)="incrementFrequence()">+</button>
                   </div>
                   <span class="frequence-separator">{{ 'enjeux.operations.foisPar' | translate }}</span>
-                  <mat-form-field appearance="outline" class="frequence-unite-field">
+                  <mat-form-field appearance="outline" class="frequence-unite-field app-mat-form-field">
                     <mat-select formControlName="frequence_unite">
                       <mat-option [value]="null">—</mat-option>
                       @for (unite of frequenceUnites; track unite.value) {

--- a/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.html
@@ -40,8 +40,9 @@
           <p class="required-notice">{{ 'enjeux.enjeuForm.requiredBefore' | translate }} <span class="required-star">*</span> {{ 'enjeux.enjeuForm.requiredAfter' | translate }}</p>
 
           <!-- Type d'action (autocomplete groupé par catégorie) -->
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'enjeux.operations.typeActionLabel' | translate }}</mat-label>
+          <label class="app-mat-label">{{ 'enjeux.operations.typeActionLabel' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+            <mat-label></mat-label>
             <input matInput
               [formControl]="typeActionSearchCtrl"
               [matAutocomplete]="autoTypeAction"
@@ -74,8 +75,9 @@
           </mat-form-field>
 
           <!-- Catégorie d'action réserve (CT88) — optionnel, prend le pas sur le préfixe du type d'action -->
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'enjeux.operations.categorieActionReserveLabel' | translate }}</mat-label>
+          <label class="app-mat-label">{{ 'enjeux.operations.categorieActionReserveLabel' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+            <mat-label></mat-label>
             <mat-select [formControl]="categorieActionReserveCtrl"
                         [placeholder]="'enjeux.operations.categorieActionReservePlaceholder' | translate">
               <mat-option [value]="null">—</mat-option>
@@ -124,8 +126,9 @@
 
             <!-- Si Oui → sélecteur d'inventaires existants -->
             @if (estSuiviExistant()) {
-              <mat-form-field appearance="outline" class="full-width">
-                <mat-label>{{ 'enjeux.operations.intituleSuiviLabel' | translate }}</mat-label>
+              <label class="app-mat-label">{{ 'enjeux.operations.intituleSuiviLabel' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+                <mat-label></mat-label>
                 <mat-select formControlName="id_suivi">
                   <mat-option [value]="null">—</mat-option>
                   @for (inv of availableInventaires(); track inv.id_suivi_inventaire) {
@@ -160,8 +163,9 @@
           }
 
           <!-- Métriques associées -->
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'enjeux.operations.metriquesAssocieesLabel' | translate }}</mat-label>
+          <label class="app-mat-label">{{ 'enjeux.operations.metriquesAssocieesLabel' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+            <mat-label></mat-label>
             <mat-select formControlName="metrique_ids" multiple>
               @for (met of planMetriques(); track met.id_metrique) {
                 <mat-option [value]="met.id_metrique">
@@ -193,8 +197,9 @@
   <img accordionIcon src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
   <div class="section-content">
 <!-- Objectif principal (grouped select) -->
-              <mat-form-field appearance="outline" class="full-width">
-                <mat-label>{{ 'enjeux.operations.objectifPrincipal' | translate }}</mat-label>
+              <label class="app-mat-label">{{ 'enjeux.operations.objectifPrincipal' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+                <mat-label></mat-label>
                 <mat-select formControlName="objectif_principal">
                   <mat-option [value]="''">—</mat-option>
                   @for (group of objectifGroups(); track group.groupLabel) {
@@ -215,8 +220,9 @@
 
               <!-- Objectif secondaire (conditional: only if objectif principal is set) -->
               @if (hasObjectifPrincipal) {
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>{{ 'enjeux.operations.objectifSecondaire' | translate }}</mat-label>
+                <label class="app-mat-label">{{ 'enjeux.operations.objectifSecondaire' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+                  <mat-label></mat-label>
                   <mat-select formControlName="objectif_secondaire">
                     <mat-option [value]="''">—</mat-option>
                     @for (group of objectifGroups(); track group.groupLabel) {
@@ -237,8 +243,9 @@
               }
 
               <!-- Cible principale -->
-              <mat-form-field appearance="outline" class="full-width">
-                <mat-label>{{ 'enjeux.operations.ciblesPrincipales' | translate }}</mat-label>
+              <label class="app-mat-label">{{ 'enjeux.operations.ciblesPrincipales' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+                <mat-label></mat-label>
                 <mat-select formControlName="cibles_principales">
                   <mat-option [value]="null">—</mat-option>
                   @for (opt of cibleSuiviOptions(); track opt.id_nomenclature) {
@@ -278,8 +285,9 @@
 
               <!-- Cible secondaire (conditional: only if cible principale is set) -->
               @if (hasCiblePrincipale) {
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>{{ 'enjeux.operations.cibleSecondaire' | translate }}</mat-label>
+                <label class="app-mat-label">{{ 'enjeux.operations.cibleSecondaire' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+                  <mat-label></mat-label>
                   <mat-select formControlName="cible_secondaire">
                     <mat-option [value]="''">—</mat-option>
                     @for (opt of cibleSuiviOptions(); track opt.id_nomenclature) {
@@ -291,8 +299,9 @@
               }
 
               <!-- Date de lancement du suivi (date picker) -->
-              <mat-form-field appearance="outline">
-                <mat-label>{{ 'inventaires.form.dateLancement' | translate }}</mat-label>
+              <label class="app-mat-label">{{ 'inventaires.form.dateLancement' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+                <mat-label></mat-label>
                 <input matInput [matDatepicker]="dateLancementPicker" formControlName="date_lancement_suivi"
                   [placeholder]="'inventaires.form.dateLancementPlaceholder' | translate">
                 <mat-datepicker-toggle matSuffix [for]="dateLancementPicker"></mat-datepicker-toggle>
@@ -322,11 +331,10 @@
               <!-- ═══ MODE CAMPANULE (Oui) ═══ -->
               @if (isCampanule) {
                 <!-- Autocomplete Protocole Campanule -->
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>
-                    {{ 'enjeux.operations.protocoleNom' | translate }}
-                    <span class="required-star">*</span>
-                  </mat-label>
+                <label class="app-mat-label">{{ 'enjeux.operations.protocoleNom' | translate }}
+                    <span class="required-star">*</span></label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+                  <mat-label></mat-label>
                   <input matInput
                     [formControl]="campanuleSearchCtrl"
                     [matAutocomplete]="campanuleAuto"
@@ -477,8 +485,9 @@
   <img accordionIcon src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
   <div class="section-content">
 <!-- Outil de bancarisation -->
-              <mat-form-field appearance="outline" class="full-width">
-                <mat-label>{{ 'enjeux.operations.outilBancarisation' | translate }}</mat-label>
+              <label class="app-mat-label">{{ 'enjeux.operations.outilBancarisation' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+                <mat-label></mat-label>
                 <mat-select formControlName="outil_bancarisation">
                   <mat-option [value]="null">—</mat-option>
                   @for (opt of bancarisationOptions(); track opt.mnemonique) {
@@ -488,8 +497,9 @@
               </mat-form-field>
 
               <!-- Existe t-il un outil de saisie ? -->
-              <mat-form-field appearance="outline" class="full-width">
-                <mat-label>{{ 'enjeux.operations.outilSaisie' | translate }}</mat-label>
+              <label class="app-mat-label">{{ 'enjeux.operations.outilSaisie' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+                <mat-label></mat-label>
                 <mat-select formControlName="outil_saisie">
                   <mat-option [value]="null">—</mat-option>
                   @for (opt of outilSaisieOptions(); track opt.mnemonique) {
@@ -912,8 +922,9 @@
                     <app-form-field [label]="'enjeux.operations.financeLibelleLabel' | translate">
   <input [(ngModel)]="finance.libelle" [ngModelOptions]="{standalone: true}">
 </app-form-field>
-                    <mat-form-field appearance="outline" class="finance-categorie">
-                      <mat-label>{{ 'enjeux.operations.categorieFinanceLabel' | translate }}</mat-label>
+                    <label class="app-mat-label">{{ 'enjeux.operations.categorieFinanceLabel' | translate }}</label>
+      <mat-form-field class="app-mat-form-field finance-categorie" appearance="outline">>
+                      <mat-label></mat-label>
                       <mat-select [(ngModel)]="finance.id_categorie" [ngModelOptions]="{standalone: true}">
                         <mat-option [value]="null">—</mat-option>
                         @for (cat of categorieFinanceOptions(); track cat.id_nomenclature) {

--- a/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.html
@@ -152,12 +152,10 @@
             }
 
             <!-- Intitulé de l'action (lecture seule, synchronisé avec l'inventaire) -->
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'enjeux.operations.libelleLabel' | translate }}</mat-label>
-              <input matInput [value]="libelleDisplay()" disabled
+            <app-form-field [label]="'enjeux.operations.libelleLabel' | translate" [helpText]="'enjeux.operations.libelleAutoFilledHint' | translate">
+  <input [value]="libelleDisplay()" disabled
                      [placeholder]="'enjeux.operations.libellePlaceholder' | translate">
-              <mat-hint>{{ 'enjeux.operations.libelleAutoFilledHint' | translate }}</mat-hint>
-            </mat-form-field>
+</app-form-field>
           }
 
           <!-- Métriques associées -->
@@ -367,13 +365,9 @@
                 </mat-form-field>
 
                 <!-- Nombre d'ETP par cycle de collecte -->
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>
-                    {{ 'enjeux.operations.nbEtpCycle' | translate }}
-                  </mat-label>
-                  <input matInput type="number" formControlName="nb_etp_cycle">
-                  <mat-hint>{{ 'enjeux.operations.nbEtpCycleHint' | translate }}</mat-hint>
-                </mat-form-field>
+                <app-form-field [label]="'enjeux.operations.nbEtpCycle' | translate" [helpText]="'enjeux.operations.nbEtpCycleHint' | translate">
+  <input type="number" formControlName="nb_etp_cycle">
+</app-form-field>
               }
 
               <!-- Respectez-vous strictement le protocole ? -->
@@ -395,15 +389,13 @@
 
               <!-- Non-respect: Justification + Différences -->
               @if (isNonRespect) {
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>{{ 'enjeux.operations.justificationNonRespect' | translate }}</mat-label>
-                  <textarea matInput formControlName="justification_non_respect" rows="3"></textarea>
-                </mat-form-field>
+                <app-form-field [label]="'enjeux.operations.justificationNonRespect' | translate">
+  <textarea formControlName="justification_non_respect" rows="3"></textarea>
+</app-form-field>
 
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>{{ 'enjeux.operations.differencesProtocole' | translate }}</mat-label>
-                  <textarea matInput formControlName="differences_protocole" rows="3"></textarea>
-                </mat-form-field>
+                <app-form-field [label]="'enjeux.operations.differencesProtocole' | translate">
+  <textarea formControlName="differences_protocole" rows="3"></textarea>
+</app-form-field>
               }
 
               <!-- Description du protocole (readonly si Campanule) -->
@@ -415,10 +407,9 @@
                   </div>
                 </div>
               } @else if (isNotCampanule) {
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>{{ 'enjeux.operations.descriptionProtocole' | translate }}</mat-label>
-                  <textarea matInput formControlName="description_protocole" rows="3"></textarea>
-                </mat-form-field>
+                <app-form-field [label]="'enjeux.operations.descriptionProtocole' | translate">
+  <textarea formControlName="description_protocole" rows="3"></textarea>
+</app-form-field>
               }
 
               <!-- Objectif du protocole (readonly si Campanule) -->
@@ -430,10 +421,9 @@
                   </div>
                 </div>
               } @else if (isNotCampanule) {
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>{{ 'enjeux.operations.objectifProtocole' | translate }}</mat-label>
-                  <textarea matInput formControlName="objectif_protocole" rows="3"></textarea>
-                </mat-form-field>
+                <app-form-field [label]="'enjeux.operations.objectifProtocole' | translate">
+  <textarea formControlName="objectif_protocole" rows="3"></textarea>
+</app-form-field>
               }
 
               <!-- Période d'échantillonnage (readonly si Campanule) -->
@@ -445,11 +435,10 @@
                   </div>
                 </div>
               } @else if (isNotCampanule) {
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>{{ 'enjeux.operations.periodeEchantillonnage' | translate }}</mat-label>
-                  <input matInput formControlName="periode_echantillonnage"
+                <app-form-field [label]="'enjeux.operations.periodeEchantillonnage' | translate">
+  <input formControlName="periode_echantillonnage"
                          [placeholder]="'enjeux.operations.periodeEchantillonnagePlaceholder' | translate">
-                </mat-form-field>
+</app-form-field>
               }
 
               <!-- Fréquence de l'action -->
@@ -905,31 +894,27 @@
               }
 
               <!-- Opérateur(s) -->
-              <mat-form-field appearance="outline" class="full-width">
-                <mat-label>{{ 'enjeux.operations.operateursLabel' | translate }}</mat-label>
-                <input matInput formControlName="operateurs">
-              </mat-form-field>
+              <app-form-field [label]="'enjeux.operations.operateursLabel' | translate">
+  <input formControlName="operateurs">
+</app-form-field>
 
               <!-- Partenaire(s) -->
-              <mat-form-field appearance="outline" class="full-width">
-                <mat-label>{{ 'enjeux.operations.partenairesLabel' | translate }}</mat-label>
-                <textarea matInput formControlName="partenaires" rows="2"></textarea>
-              </mat-form-field>
+              <app-form-field [label]="'enjeux.operations.partenairesLabel' | translate">
+  <textarea formControlName="partenaires" rows="2"></textarea>
+</app-form-field>
 
               <!-- Financeur(s) (text field) -->
-              <mat-form-field appearance="outline" class="full-width">
-                <mat-label>{{ 'enjeux.operations.financeursLabel' | translate }}</mat-label>
-                <textarea matInput formControlName="financeurs" rows="2"></textarea>
-              </mat-form-field>
+              <app-form-field [label]="'enjeux.operations.financeursLabel' | translate">
+  <textarea formControlName="financeurs" rows="2"></textarea>
+</app-form-field>
 
               <!-- Finances (relational) -->
               <div class="finances-section">
                 @for (finance of finances; track $index) {
                   <div class="finance-row">
-                    <mat-form-field appearance="outline" class="finance-libelle">
-                      <mat-label>{{ 'enjeux.operations.financeLibelleLabel' | translate }}</mat-label>
-                      <input matInput [(ngModel)]="finance.libelle" [ngModelOptions]="{standalone: true}">
-                    </mat-form-field>
+                    <app-form-field [label]="'enjeux.operations.financeLibelleLabel' | translate">
+  <input [(ngModel)]="finance.libelle" [ngModelOptions]="{standalone: true}">
+</app-form-field>
                     <mat-form-field appearance="outline" class="finance-categorie">
                       <mat-label>{{ 'enjeux.operations.categorieFinanceLabel' | translate }}</mat-label>
                       <mat-select [(ngModel)]="finance.id_categorie" [ngModelOptions]="{standalone: true}">
@@ -957,10 +942,9 @@
         <app-accordion variant="subtle" [title]="'enjeux.operations.detailsLabel' | translate" [expanded]="sectionsOpen['details']" (expandedChange)="sectionsOpen['details'] = $event">
   <img accordionIcon src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
   <div class="section-content">
-<mat-form-field appearance="outline" class="full-width">
-                <mat-label>{{ 'enjeux.operations.detailsCommentaires' | translate }}</mat-label>
-                <textarea matInput formControlName="description" rows="5"></textarea>
-              </mat-form-field>
+<app-form-field [label]="'enjeux.operations.detailsCommentaires' | translate">
+  <textarea formControlName="description" rows="5"></textarea>
+</app-form-field>
   </div>
 </app-accordion>
 

--- a/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.html
@@ -143,14 +143,13 @@
               </mat-form-field>
             } @else {
               <!-- Si Non → intitulé de l'inventaire en texte libre (requis) -->
-              <mat-form-field appearance="outline" class="full-width">
-                <mat-label>{{ 'enjeux.operations.intituleSuiviLabel' | translate }} <span class="required-star">*</span></mat-label>
-                <input matInput formControlName="intitule_suivi"
+              <app-form-field [label]="'enjeux.operations.intituleSuiviLabel' | translate" [required]="true">
+  <input formControlName="intitule_suivi"
                        [placeholder]="'enjeux.operations.intituleSuiviPlaceholder' | translate">
                 @if (form.get('intitule_suivi')?.hasError('required') && form.get('intitule_suivi')?.touched) {
-                  <mat-error>{{ 'common.validation.required' | translate }}</mat-error>
+                  
                 }
-              </mat-form-field>
+</app-form-field>
             }
 
             <!-- Intitulé de l'action (lecture seule, synchronisé avec l'inventaire) -->
@@ -358,13 +357,9 @@
               <!-- ═══ MODE NON-CAMPANULE (Non) ═══ -->
               @if (isNotCampanule) {
                 <!-- Nom du protocole (libre) -->
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>
-                    {{ 'enjeux.operations.nomProtocole' | translate }}
-                    <span class="required-star">*</span>
-                  </mat-label>
-                  <input matInput formControlName="nom_protocole">
-                </mat-form-field>
+                <app-form-field [label]="'enjeux.operations.nomProtocole' | translate" [required]="true">
+  <input formControlName="nom_protocole">
+</app-form-field>
 
                 <!-- Nombre d'ETP par cycle de collecte -->
                 <app-form-field [label]="'enjeux.operations.nbEtpCycle' | translate" [helpText]="'enjeux.operations.nbEtpCycleHint' | translate">

--- a/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.html
@@ -99,15 +99,17 @@
 
           <!-- Intitulé de l'action : contrôle formulaire (caché quand CS, affiché en position basse) -->
           <div [style.display]="isCSAction() ? 'none' : ''">
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ 'enjeux.operations.libelleLabel' | translate }}</mat-label>
-              <input matInput formControlName="libelle"
+            <app-form-field [label]="'enjeux.operations.libelleLabel' | translate" [helpText]="'enjeux.operations.libelleHint' | translate">
+  <input formControlName="libelle"
                      [placeholder]="'enjeux.operations.libellePlaceholder' | translate">
-              <mat-hint>{{ 'enjeux.operations.libelleHint' | translate }}</mat-hint>
+              
               @if (form.get('libelle')?.hasError('maxlength')) {
-                <mat-error>{{ 'common.validation.maxLength' | translate:{ max: 500 } }}</mat-error>
+                
               }
-            </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'common.validation.maxLength' | translate:{ max: 500 } }}</p>
+  </ng-container>
+</app-form-field>
           </div>
 
           <!-- Question suivi existant (visible uniquement pour les actions CS) -->

--- a/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.html
@@ -575,12 +575,9 @@
                   <span class="field-label">{{ 'enjeux.operations.actionLieeAux' | translate }}</span>
                   <div class="sites-checkboxes">
                     @for (site of planSites(); track site.id_site) {
-                      <mat-checkbox
-                        [checked]="selectedSiteIds[site.id_site]"
+                      <app-checkbox [checked]="selectedSiteIds[site.id_site]"
                         (change)="toggleSite(site.id_site)"
-                        color="primary">
-                        {{ site.nom_site }}
-                      </mat-checkbox>
+                        color="primary" [label]="site.nom_site"></app-checkbox>
                     }
                   </div>
                 </div>
@@ -626,11 +623,9 @@
                           <td class="label-cell">{{ 'enjeux.operations.progPeriodicite' | translate }}</td>
                           @for (annee of operationAnnees; track annee.annee; let i = $index) {
                             <td>
-                              <mat-checkbox
-                                [checked]="annee.periodicite"
+                              <app-checkbox [checked]="annee.periodicite"
                                 (change)="togglePeriodicite(i)"
-                                color="primary">
-                              </mat-checkbox>
+                                color="primary"></app-checkbox>
                             </td>
                           }
                         </tr>
@@ -935,11 +930,9 @@
                           <td class="label-cell">{{ 'enjeux.operations.progPeriodicite' | translate }}</td>
                           @for (month of months; track month) {
                             <td>
-                              <mat-checkbox
-                                [checked]="programmationMensuelleDefaut[month.toString()]"
+                              <app-checkbox [checked]="programmationMensuelleDefaut[month.toString()]"
                                 (change)="toggleMensuelleDefaut(month.toString())"
-                                color="primary">
-                              </mat-checkbox>
+                                color="primary"></app-checkbox>
                             </td>
                           }
                         </tr>

--- a/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.html
+++ b/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.html
@@ -190,19 +190,10 @@
         <!-- (visible uniquement pour les actions CS)        -->
         <!-- ═══════════════════════════════════════════════ -->
         @if (isCSAction()) {
-        <div class="form-card" [class.readonly-section]="estSuiviExistant()">
-          <div class="section-header" (click)="toggleSection('details_suivi')">
-            <div class="section-title-row">
-              <img src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
-              <h3 class="section-label">{{ 'enjeux.operations.detailsSuiviTitle' | translate }}</h3>
-            </div>
-            <i class="fi section-chevron" [class.fi-rr-angle-up]="sectionsOpen['details_suivi']" [class.fi-rr-angle-down]="!sectionsOpen['details_suivi']"></i>
-          </div>
-          <div class="section-underline"></div>
-
-          @if (sectionsOpen['details_suivi']) {
-            <div class="section-content">
-              <!-- Objectif principal (grouped select) -->
+        <app-accordion variant="subtle" [title]="'enjeux.operations.detailsSuiviTitle' | translate" [expanded]="sectionsOpen['details_suivi']" (expandedChange)="sectionsOpen['details_suivi'] = $event" [class.readonly-section]="estSuiviExistant()">
+  <img accordionIcon src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
+  <div class="section-content">
+<!-- Objectif principal (grouped select) -->
               <mat-form-field appearance="outline" class="full-width">
                 <mat-label>{{ 'enjeux.operations.objectifPrincipal' | translate }}</mat-label>
                 <mat-select formControlName="objectif_principal">
@@ -308,26 +299,16 @@
                 <mat-datepicker-toggle matSuffix [for]="dateLancementPicker"></mat-datepicker-toggle>
                 <mat-datepicker #dateLancementPicker></mat-datepicker>
               </mat-form-field>
-            </div>
-          }
-        </div>
+  </div>
+</app-accordion>
 
         <!-- ═══════════════════════════════════════════════ -->
         <!-- SECTION: Protocole                             -->
         <!-- ═══════════════════════════════════════════════ -->
-        <div class="form-card" [class.readonly-section]="estSuiviExistant()">
-          <div class="section-header" (click)="toggleSection('protocole')">
-            <div class="section-title-row">
-              <img src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
-              <h3 class="section-label">{{ 'enjeux.operations.protocoleTitle' | translate }}</h3>
-            </div>
-            <i class="fi section-chevron" [class.fi-rr-angle-up]="sectionsOpen['protocole']" [class.fi-rr-angle-down]="!sectionsOpen['protocole']"></i>
-          </div>
-          <div class="section-underline"></div>
-
-          @if (sectionsOpen['protocole']) {
-            <div class="section-content">
-              <!-- Protocole répertorié dans Campanule -->
+        <app-accordion variant="subtle" [title]="'enjeux.operations.protocoleTitle' | translate" [expanded]="sectionsOpen['protocole']" (expandedChange)="sectionsOpen['protocole'] = $event" [class.readonly-section]="estSuiviExistant()">
+  <img accordionIcon src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
+  <div class="section-content">
+<!-- Protocole répertorié dans Campanule -->
               <div class="radio-field-row">
                 <span class="radio-field-label">
                   {{ 'enjeux.operations.protocoleCampanule' | translate }}
@@ -500,26 +481,16 @@
                   </button>
                 </div>
               </div>
-            </div>
-          }
-        </div>
+  </div>
+</app-accordion>
 
         <!-- ═══════════════════════════════════════════════ -->
         <!-- SECTION: Bancarisation et stockage             -->
         <!-- ═══════════════════════════════════════════════ -->
-        <div class="form-card" [class.readonly-section]="estSuiviExistant()">
-          <div class="section-header" (click)="toggleSection('bancarisation')">
-            <div class="section-title-row">
-              <img src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
-              <h3 class="section-label">{{ 'enjeux.operations.bancarisationTitle' | translate }}</h3>
-            </div>
-            <i class="fi section-chevron" [class.fi-rr-angle-up]="sectionsOpen['bancarisation']" [class.fi-rr-angle-down]="!sectionsOpen['bancarisation']"></i>
-          </div>
-          <div class="section-underline"></div>
-
-          @if (sectionsOpen['bancarisation']) {
-            <div class="section-content">
-              <!-- Outil de bancarisation -->
+        <app-accordion variant="subtle" [title]="'enjeux.operations.bancarisationTitle' | translate" [expanded]="sectionsOpen['bancarisation']" (expandedChange)="sectionsOpen['bancarisation'] = $event" [class.readonly-section]="estSuiviExistant()">
+  <img accordionIcon src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
+  <div class="section-content">
+<!-- Outil de bancarisation -->
               <mat-form-field appearance="outline" class="full-width">
                 <mat-label>{{ 'enjeux.operations.outilBancarisation' | translate }}</mat-label>
                 <mat-select formControlName="outil_bancarisation">
@@ -549,27 +520,17 @@
                   <mat-radio-button [value]="false" color="primary">{{ 'common.no' | translate }}</mat-radio-button>
                 </mat-radio-group>
               </div>
-            </div>
-          }
-        </div>
+  </div>
+</app-accordion>
         } <!-- fin @if (isCSAction()) — sections Détails/Protocole/Bancarisation -->
 
         <!-- ═══════════════════════════════════════════════ -->
         <!-- SECTION: Programmation                         -->
         <!-- ═══════════════════════════════════════════════ -->
-        <div class="form-card">
-          <div class="section-header" (click)="toggleSection('programmation')">
-            <div class="section-title-row">
-              <img src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
-              <h3 class="section-label">{{ 'enjeux.operations.programmationTitle' | translate }}</h3>
-            </div>
-            <i class="fi section-chevron" [class.fi-rr-angle-up]="sectionsOpen['programmation']" [class.fi-rr-angle-down]="!sectionsOpen['programmation']"></i>
-          </div>
-          <div class="section-underline"></div>
-
-          @if (sectionsOpen['programmation']) {
-            <div class="section-content">
-              <!-- L'action est liée au/aux (masqué si plan mono-site) -->
+        <app-accordion variant="subtle" [title]="'enjeux.operations.programmationTitle' | translate" [expanded]="sectionsOpen['programmation']" (expandedChange)="sectionsOpen['programmation'] = $event">
+  <img accordionIcon src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
+  <div class="section-content">
+<!-- L'action est liée au/aux (masqué si plan mono-site) -->
               @if (planSites().length > 1) {
                 <div class="sites-selection">
                   <span class="field-label">{{ 'enjeux.operations.actionLieeAux' | translate }}</span>
@@ -987,76 +948,45 @@
                   + {{ 'enjeux.operations.addFinance' | translate }}
                 </button>
               </div>
-            </div>
-          }
-        </div>
+  </div>
+</app-accordion>
 
         <!-- ═══════════════════════════════════════════════ -->
         <!-- SECTION: Détails                               -->
         <!-- ═══════════════════════════════════════════════ -->
-        <div class="form-card">
-          <div class="section-header" (click)="toggleSection('details')">
-            <div class="section-title-row">
-              <img src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
-              <h3 class="section-label">{{ 'enjeux.operations.detailsLabel' | translate }}</h3>
-            </div>
-            <i class="fi section-chevron" [class.fi-rr-angle-up]="sectionsOpen['details']" [class.fi-rr-angle-down]="!sectionsOpen['details']"></i>
-          </div>
-          <div class="section-underline"></div>
-
-          @if (sectionsOpen['details']) {
-            <div class="section-content">
-              <mat-form-field appearance="outline" class="full-width">
+        <app-accordion variant="subtle" [title]="'enjeux.operations.detailsLabel' | translate" [expanded]="sectionsOpen['details']" (expandedChange)="sectionsOpen['details'] = $event">
+  <img accordionIcon src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
+  <div class="section-content">
+<mat-form-field appearance="outline" class="full-width">
                 <mat-label>{{ 'enjeux.operations.detailsCommentaires' | translate }}</mat-label>
                 <textarea matInput formControlName="description" rows="5"></textarea>
               </mat-form-field>
-            </div>
-          }
-        </div>
+  </div>
+</app-accordion>
 
         <!-- ═══════════════════════════════════════════════ -->
         <!-- SECTION: Emprise spatiale                      -->
         <!-- ═══════════════════════════════════════════════ -->
-        <div class="form-card">
-          <div class="section-header" (click)="toggleSection('emprise')">
-            <div class="section-title-row">
-              <img src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
-              <h3 class="section-label">{{ 'enjeux.operations.empriseSpatiale' | translate }}</h3>
-            </div>
-            <i class="fi section-chevron" [class.fi-rr-angle-up]="sectionsOpen['emprise']" [class.fi-rr-angle-down]="!sectionsOpen['emprise']"></i>
-          </div>
-          <div class="section-underline"></div>
-
-          @if (sectionsOpen['emprise']) {
-            <div class="section-content">
-              <button type="button" class="add-link-btn">
+        <app-accordion variant="subtle" [title]="'enjeux.operations.empriseSpatiale' | translate" [expanded]="sectionsOpen['emprise']" (expandedChange)="sectionsOpen['emprise'] = $event">
+  <img accordionIcon src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
+  <div class="section-content">
+<button type="button" class="add-link-btn">
                 + {{ 'enjeux.operations.ajouterEmprise' | translate }}
               </button>
-            </div>
-          }
-        </div>
+  </div>
+</app-accordion>
 
         <!-- ═══════════════════════════════════════════════ -->
         <!-- SECTION: Indicateur(s) de réponse              -->
         <!-- ═══════════════════════════════════════════════ -->
-        <div class="form-card">
-          <div class="section-header" (click)="toggleSection('indicateurs_reponse')">
-            <div class="section-title-row">
-              <img src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
-              <h3 class="section-label">{{ 'enjeux.operations.indicateursReponse' | translate }}</h3>
-            </div>
-            <i class="fi section-chevron" [class.fi-rr-angle-up]="sectionsOpen['indicateurs_reponse']" [class.fi-rr-angle-down]="!sectionsOpen['indicateurs_reponse']"></i>
-          </div>
-          <div class="section-underline"></div>
-
-          @if (sectionsOpen['indicateurs_reponse']) {
-            <div class="section-content">
-              <button type="button" class="add-link-btn">
+        <app-accordion variant="subtle" [title]="'enjeux.operations.indicateursReponse' | translate" [expanded]="sectionsOpen['indicateurs_reponse']" (expandedChange)="sectionsOpen['indicateurs_reponse'] = $event">
+  <img accordionIcon src="assets/images/ellipses/ellipse-yellow.png" alt="" class="section-dot">
+  <div class="section-content">
+<button type="button" class="add-link-btn">
                 + {{ 'enjeux.operations.ajouterIndicateurReponse' | translate }}
               </button>
-            </div>
-          }
-        </div>
+  </div>
+</app-accordion>
 
       </form>
     </div>

--- a/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.ts
+++ b/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.ts
@@ -28,6 +28,7 @@ import { HeaderComponent } from '../../../../shared/components/header/header.com
 import { ReferenceItemListComponent } from '../../../../shared/components/reference-item-list/reference-item-list.component';
 import { CheckboxComponent } from '../../../../shared/components/checkbox/checkbox.component';
 import { AccordionComponent } from '../../../../shared/components/accordion/accordion.component';
+import { FormFieldComponent } from '../../../../shared/components/form-field/form-field.component';
 import { EnjeuService } from '../../../../core/services/enjeu.service';
 import { AdminService } from '../../../../core/services/admin.service';
 import { CampanuleService } from '../../../../core/services/campanule.service';
@@ -70,6 +71,7 @@ import {
     HeaderComponent,
     ReferenceItemListComponent,
     AccordionComponent,
+    FormFieldComponent,
   ],
   templateUrl: './operation-form.component.html',
   styleUrl: './operation-form.component.scss'

--- a/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.ts
+++ b/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.ts
@@ -14,7 +14,6 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatSelectModule } from '@angular/material/select';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatDatepickerModule } from '@angular/material/datepicker';
@@ -27,6 +26,7 @@ import { debounceTime, distinctUntilChanged, filter, switchMap } from 'rxjs/oper
 
 import { HeaderComponent } from '../../../../shared/components/header/header.component';
 import { ReferenceItemListComponent } from '../../../../shared/components/reference-item-list/reference-item-list.component';
+import { CheckboxComponent } from '../../../../shared/components/checkbox/checkbox.component';
 import { EnjeuService } from '../../../../core/services/enjeu.service';
 import { AdminService } from '../../../../core/services/admin.service';
 import { CampanuleService } from '../../../../core/services/campanule.service';
@@ -57,7 +57,7 @@ import {
     MatButtonModule,
     MatButtonToggleModule,
     MatSelectModule,
-    MatCheckboxModule,
+    CheckboxComponent,
     MatRadioModule,
     MatProgressSpinnerModule,
     MatDatepickerModule,

--- a/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.ts
+++ b/frontend/src/app/features/plans/enjeux/operation-form/operation-form.component.ts
@@ -27,6 +27,7 @@ import { debounceTime, distinctUntilChanged, filter, switchMap } from 'rxjs/oper
 import { HeaderComponent } from '../../../../shared/components/header/header.component';
 import { ReferenceItemListComponent } from '../../../../shared/components/reference-item-list/reference-item-list.component';
 import { CheckboxComponent } from '../../../../shared/components/checkbox/checkbox.component';
+import { AccordionComponent } from '../../../../shared/components/accordion/accordion.component';
 import { EnjeuService } from '../../../../core/services/enjeu.service';
 import { AdminService } from '../../../../core/services/admin.service';
 import { CampanuleService } from '../../../../core/services/campanule.service';
@@ -67,7 +68,8 @@ import {
     MatTooltipModule,
     TranslateModule,
     HeaderComponent,
-    ReferenceItemListComponent
+    ReferenceItemListComponent,
+    AccordionComponent,
   ],
   templateUrl: './operation-form.component.html',
   styleUrl: './operation-form.component.scss'

--- a/frontend/src/app/features/plans/plan-create.component.html
+++ b/frontend/src/app/features/plans/plan-create.component.html
@@ -242,7 +242,7 @@
               </div>
             } @else {
               <!-- Input avec autocomplete -->
-              <mat-form-field appearance="outline" class="full-width">
+              <mat-form-field appearance="outline" class="full-width app-mat-form-field">
                 <input
                   matInput
                   #organismeInput

--- a/frontend/src/app/features/plans/plan-create.component.html
+++ b/frontend/src/app/features/plans/plan-create.component.html
@@ -56,13 +56,15 @@
           }
 
           <!-- Nom du plan * -->
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'modals.planForm.fields.name' | translate }} *</mat-label>
-            <input matInput formControlName="nom" [placeholder]="'modals.planForm.placeholders.name' | translate">
+          <app-form-field [label]="('modals.planForm.fields.name' | translate) + ' *'" [required]="true">
+  <input formControlName="nom" [placeholder]="'modals.planForm.placeholders.name' | translate">
             @if (form.get('nom')?.hasError('required')) {
-              <mat-error>{{ 'modals.planForm.validation.nameRequired' | translate }}</mat-error>
+              
             }
-          </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'modals.planForm.validation.nameRequired' | translate }}</p>
+  </ng-container>
+</app-form-field>
 
           <!-- Choix des sites * -->
           <div class="form-section-box sites-section">
@@ -142,17 +144,20 @@
 
           <!-- Rang et Surface -->
           <div class="form-row">
-            <mat-form-field appearance="outline">
-              <mat-label>{{ 'modals.planForm.fields.rang' | translate }} *</mat-label>
-              <input matInput type="number" formControlName="rang" min="1">
-              <mat-hint>{{ 'modals.planForm.hints.rang' | translate }}</mat-hint>
+            <app-form-field [label]="('modals.planForm.fields.rang' | translate) + ' *'" [required]="true" [helpText]="'modals.planForm.hints.rang' | translate">
+  <input type="number" formControlName="rang" min="1">
+              
               @if (form.get('rang')?.hasError('required')) {
-                <mat-error>{{ 'modals.planForm.validation.rangRequired' | translate }}</mat-error>
+                
               }
               @if (form.get('rang')?.hasError('min')) {
-                <mat-error>{{ 'modals.planForm.validation.rangMin' | translate }}</mat-error>
+                
               }
-            </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'modals.planForm.validation.rangRequired' | translate }}</p>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'modals.planForm.validation.rangMin' | translate }}</p>
+  </ng-container>
+</app-form-field>
 
             <app-form-field
               [label]="'modals.planForm.fields.surface' | translate"
@@ -173,21 +178,25 @@
 
           <!-- Année début et Année fin -->
           <div class="form-row">
-            <mat-form-field appearance="outline">
-              <mat-label>{{ 'modals.planForm.fields.startYear' | translate }} *</mat-label>
-              <input matInput type="number" formControlName="annee_debut" min="1900" max="2100">
+            <app-form-field [label]="('modals.planForm.fields.startYear' | translate) + ' *'" [required]="true">
+  <input type="number" formControlName="annee_debut" min="1900" max="2100">
               @if (form.get('annee_debut')?.hasError('required')) {
-                <mat-error>{{ 'common.validation.required' | translate }}</mat-error>
+                
               }
-            </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'common.validation.required' | translate }}</p>
+  </ng-container>
+</app-form-field>
 
-            <mat-form-field appearance="outline">
-              <mat-label>{{ 'modals.planForm.fields.endYear' | translate }} *</mat-label>
-              <input matInput type="number" formControlName="annee_fin" min="1900" max="2100">
+            <app-form-field [label]="('modals.planForm.fields.endYear' | translate) + ' *'" [required]="true">
+  <input type="number" formControlName="annee_fin" min="1900" max="2100">
               @if (form.get('annee_fin')?.hasError('required')) {
-                <mat-error>{{ 'common.validation.required' | translate }}</mat-error>
+                
               }
-            </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'common.validation.required' | translate }}</p>
+  </ng-container>
+</app-form-field>
           </div>
 
           <!-- Date validation CSPN -->

--- a/frontend/src/app/features/plans/plan-create.component.html
+++ b/frontend/src/app/features/plans/plan-create.component.html
@@ -200,8 +200,9 @@
           </div>
 
           <!-- Date validation CSPN -->
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'modals.planForm.fields.cspnDate' | translate }}</mat-label>
+          <label class="app-mat-label">{{ 'modals.planForm.fields.cspnDate' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+            <mat-label></mat-label>
             <input matInput [matDatepicker]="cspnPicker" formControlName="date_avis_csrpn">
             <mat-datepicker-toggle matIconSuffix [for]="cspnPicker"></mat-datepicker-toggle>
             <mat-datepicker #cspnPicker></mat-datepicker>
@@ -213,8 +214,9 @@
 </app-form-field>
 
           <!-- Type organisme rédacteur -->
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'modals.planForm.fields.editorType' | translate }}</mat-label>
+          <label class="app-mat-label">{{ 'modals.planForm.fields.editorType' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+            <mat-label></mat-label>
             <mat-select formControlName="id_redacteur_type">
               <mat-option [value]="null">{{ 'common.none' | translate }}</mat-option>
               @for (type of redacteurTypes(); track type.id_nomenclature) {

--- a/frontend/src/app/features/plans/plan-create.component.html
+++ b/frontend/src/app/features/plans/plan-create.component.html
@@ -84,16 +84,12 @@
               }
             </div>
 
-            <div class="search-box">
-              <i class="fi fi-rr-search"></i>
-              <input
-                type="text"
-                [placeholder]="'modals.planForm.placeholders.searchSite' | translate"
-                [(ngModel)]="siteSearchQuery"
-                [ngModelOptions]="{standalone: true}"
-                (ngModelChange)="filterSites()"
-              />
-            </div>
+            <app-search-bar
+              [(value)]="siteSearchQuery"
+              [placeholder]="'modals.planForm.placeholders.searchSite' | translate"
+              [ariaLabel]="'modals.planForm.placeholders.searchSite' | translate"
+              (valueChange)="filterSites()">
+            </app-search-bar>
 
             <div class="selection-list">
               @for (site of filteredSites(); track site.id) {

--- a/frontend/src/app/features/plans/plan-create.component.html
+++ b/frontend/src/app/features/plans/plan-create.component.html
@@ -154,12 +154,12 @@
               }
             </mat-form-field>
 
-            <mat-form-field appearance="outline">
-              <mat-label>{{ 'modals.planForm.fields.surface' | translate }}</mat-label>
-              <input matInput type="number" formControlName="surface" step="0.01">
-              <span matTextSuffix>ha</span>
-              <mat-hint>{{ 'modals.planForm.hints.surface' | translate }}</mat-hint>
-            </mat-form-field>
+            <app-form-field
+              [label]="'modals.planForm.fields.surface' | translate"
+              [helpText]="'modals.planForm.hints.surface' | translate"
+              suffix="ha">
+              <input type="number" formControlName="surface" step="0.01">
+            </app-form-field>
           </div>
 
           <!-- CT88 (Radio buttons) -->
@@ -199,11 +199,9 @@
           </mat-form-field>
 
           <!-- ID Doc'Gestion FCEN -->
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'modals.planForm.fields.docGestion' | translate }}</mat-label>
-            <input matInput formControlName="id_docgestion_fcen">
-            <mat-hint>{{ 'modals.planForm.hints.docGestion' | translate }}</mat-hint>
-          </mat-form-field>
+          <app-form-field [label]="'modals.planForm.fields.docGestion' | translate" [helpText]="'modals.planForm.hints.docGestion' | translate">
+  <input formControlName="id_docgestion_fcen">
+</app-form-field>
 
           <!-- Type organisme rédacteur -->
           <mat-form-field appearance="outline" class="full-width">
@@ -265,41 +263,33 @@
           </div>
 
           <!-- Rédacteurs (texte libre) -->
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'modals.planForm.fields.redacteurs' | translate }}</mat-label>
-            <textarea
-              matInput
+          <app-form-field [label]="'modals.planForm.fields.redacteurs' | translate" [helpText]="'modals.planForm.hints.redacteurs' | translate">
+  <textarea
               formControlName="redacteurs"
               rows="2"
               [placeholder]="'modals.planForm.placeholders.redacteurs' | translate"
               data-testid="redacteurs-input"
             ></textarea>
-            <mat-hint>{{ 'modals.planForm.hints.redacteurs' | translate }}</mat-hint>
-          </mat-form-field>
+</app-form-field>
 
           <!-- Relecteurs (texte libre) -->
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'modals.planForm.fields.relecteurs' | translate }}</mat-label>
-            <textarea
-              matInput
+          <app-form-field [label]="'modals.planForm.fields.relecteurs' | translate" [helpText]="'modals.planForm.hints.relecteurs' | translate">
+  <textarea
               formControlName="relecteurs"
               rows="2"
               [placeholder]="'modals.planForm.placeholders.relecteurs' | translate"
               data-testid="relecteurs-input"
             ></textarea>
-            <mat-hint>{{ 'modals.planForm.hints.relecteurs' | translate }}</mat-hint>
-          </mat-form-field>
+</app-form-field>
 
           <!-- Autres rédacteurs (texte libre) -->
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'modals.planForm.fields.autresContributeurs' | translate }}</mat-label>
-            <textarea
-              matInput
+          <app-form-field [label]="'modals.planForm.fields.autresContributeurs' | translate">
+  <textarea
               formControlName="autres_contributeurs"
               rows="2"
               [placeholder]="'modals.planForm.placeholders.autresContributeurs' | translate"
             ></textarea>
-          </mat-form-field>
+</app-form-field>
         </form>
       </div>
     }

--- a/frontend/src/app/features/plans/plan-create.component.html
+++ b/frontend/src/app/features/plans/plan-create.component.html
@@ -100,11 +100,11 @@
                   (click)="toggleSite(site.id)"
                 >
                   <div class="item-info">
-                    <mat-checkbox
+                    <app-checkbox
                       [checked]="isSiteSelected(site.id)"
                       (click)="$event.stopPropagation()"
-                      (change)="toggleSite(site.id)"
-                    ></mat-checkbox>
+                      (checkedChange)="toggleSite(site.id)">
+                    </app-checkbox>
                     <span class="item-name">{{ site.nom }}</span>
                     @if (site.type) {
                       <span class="item-type">{{ site.type }}</span>

--- a/frontend/src/app/features/plans/plan-create.component.ts
+++ b/frontend/src/app/features/plans/plan-create.component.ts
@@ -525,8 +525,9 @@ export class PlanCreateComponent implements OnInit {
         banner.scrollIntoView({ behavior: 'smooth', block: 'center' });
         return;
       }
-      const invalid = this.elRef.nativeElement.querySelector('mat-form-field.ng-invalid');
-      invalid?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      // Cherche le premier champ invalide : input/textarea natif (dans app-form-field) ou mat-form-field
+      const invalidNative = this.elRef.nativeElement.querySelector('input.ng-invalid, textarea.ng-invalid, mat-form-field.ng-invalid');
+      invalidNative?.scrollIntoView({ behavior: 'smooth', block: 'center' });
     });
   }
 

--- a/frontend/src/app/features/plans/plan-create.component.ts
+++ b/frontend/src/app/features/plans/plan-create.component.ts
@@ -15,7 +15,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSelectModule } from '@angular/material/select';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatDatepickerModule } from '@angular/material/datepicker';
@@ -32,6 +31,7 @@ import { AdminService } from '../../core/services/admin.service';
 import { AuthService } from '../../core/services/auth.service';
 import { HeaderComponent } from '../../shared/components/header/header.component';
 import { SearchBarComponent } from '../../shared/components/search-bar/search-bar.component';
+import { CheckboxComponent } from '../../shared/components/checkbox/checkbox.component';
 import { ViewScopeToggleComponent, ViewScope } from '../../shared/components/view-scope-toggle/view-scope-toggle.component';
 import { SiteFormModalComponent, SiteFormModalResult } from '../../shared/components/modals/site-form-modal/site-form-modal.component';
 import {
@@ -75,7 +75,6 @@ interface OrganismeEntry {
     MatInputModule,
     MatButtonModule,
     MatSelectModule,
-    MatCheckboxModule,
     MatProgressSpinnerModule,
     MatRadioModule,
     MatDatepickerModule,
@@ -90,6 +89,7 @@ interface OrganismeEntry {
     HeaderComponent,
     ViewScopeToggleComponent,
     SearchBarComponent,
+    CheckboxComponent,
   ],
   templateUrl: './plan-create.component.html',
   styleUrl: './plan-create.component.scss'

--- a/frontend/src/app/features/plans/plan-create.component.ts
+++ b/frontend/src/app/features/plans/plan-create.component.ts
@@ -31,6 +31,7 @@ import { Observable, map, startWith, debounceTime } from 'rxjs';
 import { AdminService } from '../../core/services/admin.service';
 import { AuthService } from '../../core/services/auth.service';
 import { HeaderComponent } from '../../shared/components/header/header.component';
+import { SearchBarComponent } from '../../shared/components/search-bar/search-bar.component';
 import { ViewScopeToggleComponent, ViewScope } from '../../shared/components/view-scope-toggle/view-scope-toggle.component';
 import { SiteFormModalComponent, SiteFormModalResult } from '../../shared/components/modals/site-form-modal/site-form-modal.component';
 import {
@@ -87,7 +88,8 @@ interface OrganismeEntry {
     MatSnackBarModule,
     TranslateModule,
     HeaderComponent,
-    ViewScopeToggleComponent
+    ViewScopeToggleComponent,
+    SearchBarComponent,
   ],
   templateUrl: './plan-create.component.html',
   styleUrl: './plan-create.component.scss'

--- a/frontend/src/app/features/plans/plan-create.component.ts
+++ b/frontend/src/app/features/plans/plan-create.component.ts
@@ -32,6 +32,7 @@ import { AuthService } from '../../core/services/auth.service';
 import { HeaderComponent } from '../../shared/components/header/header.component';
 import { SearchBarComponent } from '../../shared/components/search-bar/search-bar.component';
 import { CheckboxComponent } from '../../shared/components/checkbox/checkbox.component';
+import { FormFieldComponent } from '../../shared/components/form-field/form-field.component';
 import { ViewScopeToggleComponent, ViewScope } from '../../shared/components/view-scope-toggle/view-scope-toggle.component';
 import { SiteFormModalComponent, SiteFormModalResult } from '../../shared/components/modals/site-form-modal/site-form-modal.component';
 import {
@@ -90,6 +91,7 @@ interface OrganismeEntry {
     ViewScopeToggleComponent,
     SearchBarComponent,
     CheckboxComponent,
+    FormFieldComponent,
   ],
   templateUrl: './plan-create.component.html',
   styleUrl: './plan-create.component.scss'

--- a/frontend/src/app/features/plans/plan-detail.component.html
+++ b/frontend/src/app/features/plans/plan-detail.component.html
@@ -494,38 +494,33 @@
               <div class="sites-list">
                 @for (site of plan()!.sites!; track site.id_site) {
                   @if (site.current_user_has_access !== false) {
-                    <a class="site-card" [routerLink]="['/sites', site.slug]"
-                       [title]="'sites.actions.view' | translate">
-                      <div class="site-info">
-                        <span class="site-name">{{ site.nom_site }}</span>
-                        @if (site.type_site_label) {
-                          <span class="site-type">{{ site.type_site_label }}</span>
-                        }
-                      </div>
-                      <span class="site-card-cta" aria-hidden="true">
+                    <app-entity-tile
+                      icon="fi-rr-marker"
+                      [name]="site.nom_site"
+                      [subtitle]="site.type_site_label || ''"
+                      [routerLink]="['/sites', site.slug]"
+                      [title]="'sites.actions.view' | translate">
+                      <span tileAction class="site-card-cta" aria-hidden="true">
                         <i class="fi fi-rr-arrow-right"></i>
                       </span>
-                    </a>
+                    </app-entity-tile>
                   } @else {
-                    <div class="site-card site-card-locked">
-                      <div class="site-info">
-                        <span class="site-name">{{ site.nom_site }}</span>
-                        @if (site.type_site_label) {
-                          <span class="site-type">{{ site.type_site_label }}</span>
-                        }
-                        <div class="site-request-actions">
-                          @if (authService.isAdminOrganisme()) {
-                            <button class="site-request-access-btn" (click)="requestSiteAccess(site)">
-                              {{ 'plans.detail.linkSitePersonal' | translate }}
-                            </button>
-                          }
-                          <button class="site-request-access-btn" (click)="requestSiteOrgLink(site)">
-                            {{ 'plans.detail.linkSiteOrg' | translate }}
+                    <app-entity-tile
+                      icon="fi-rr-marker"
+                      [name]="site.nom_site"
+                      [subtitle]="site.type_site_label || ''"
+                      [locked]="true">
+                      <div class="site-request-actions">
+                        @if (authService.isAdminOrganisme()) {
+                          <button class="site-request-access-btn" (click)="requestSiteAccess(site)">
+                            {{ 'plans.detail.linkSitePersonal' | translate }}
                           </button>
-                        </div>
+                        }
+                        <button class="site-request-access-btn" (click)="requestSiteOrgLink(site)">
+                          {{ 'plans.detail.linkSiteOrg' | translate }}
+                        </button>
                       </div>
-                      <i class="fi fi-rr-lock"></i>
-                    </div>
+                    </app-entity-tile>
                   }
                 }
               </div>
@@ -542,13 +537,11 @@
                 <span class="pending-sites-label">{{ 'plans.detail.pendingSites' | translate }}</span>
                 <div class="pending-sites-list">
                   @for (req of pendingSiteRequests(); track req.id) {
-                    <div class="site-card site-card-pending">
-                      <div class="site-info">
-                        <span class="site-name">{{ req.target_name }}</span>
-                        <span class="status-badge status-warning">{{ 'common.status.pending' | translate }}</span>
-                      </div>
-                      <i class="fi fi-rr-hourglass"></i>
-                    </div>
+                    <app-entity-tile
+                      icon="fi-rr-hourglass"
+                      [name]="req.target_name || ''">
+                      <span tileAction class="status-badge status-warning">{{ 'common.status.pending' | translate }}</span>
+                    </app-entity-tile>
                   }
                 </div>
               </div>
@@ -575,17 +568,16 @@
             @if (planMembers().length > 0) {
               <div class="users-list">
                 @for (member of planMembers(); track member.id_role) {
-                  <div class="user-card-small">
-                    <div class="user-avatar-small">
-                      <i class="fi fi-rr-user"></i>
-                    </div>
-                    <div class="user-info-small">
-                      <span class="user-name-small">{{ member.nom_complet || member.email }}</span>
-                      <span class="user-role-chip" [class.role-referent]="member.referent" [class.role-member]="!member.referent">
-                        {{ (member.referent ? 'plans.detail.referent' : 'plans.detail.member') | translate }}
-                      </span>
-                    </div>
-                  </div>
+                  <app-entity-tile
+                    icon="fi-rr-user"
+                    [name]="member.nom_complet || member.email">
+                    <span tileAction
+                          class="user-role-chip"
+                          [class.role-referent]="member.referent"
+                          [class.role-member]="!member.referent">
+                      {{ (member.referent ? 'plans.detail.referent' : 'plans.detail.member') | translate }}
+                    </span>
+                  </app-entity-tile>
                 }
               </div>
             } @else {

--- a/frontend/src/app/features/plans/plan-detail.component.ts
+++ b/frontend/src/app/features/plans/plan-detail.component.ts
@@ -19,6 +19,7 @@ import { ValidationService } from '../../core/services/validation.service';
 import { ValidationRequestListItem } from '../../core/models/notification.model';
 import { AdminPlan, PlanFichier, PlanMembre, PlanSite, PlanStatut, PlanVersionChainItem } from '../../core/models/admin.model';
 import { PlanVersionTimelineComponent } from '../../shared/components/plan-version-timeline/plan-version-timeline.component';
+import { EntityTileComponent } from '../../shared/components/entity-tile/entity-tile.component';
 import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog/confirm-dialog.component';
 import { Enjeu } from '../../core/models/enjeu.model';
 import {
@@ -121,6 +122,7 @@ interface SubAccordion {
     SectionTitleComponent,
     PlanSidebarComponent,
     PlanVersionTimelineComponent,
+    EntityTileComponent,
   ],
   templateUrl: './plan-detail.component.html',
   styleUrl: './plan-detail.component.scss'

--- a/frontend/src/app/features/plans/plan-duplicate.component.html
+++ b/frontend/src/app/features/plans/plan-duplicate.component.html
@@ -9,15 +9,13 @@
   <!-- Toolbar -->
   <div class="toolbar">
     <div class="toolbar-row">
-      <mat-form-field appearance="outline" class="search-field">
-        <mat-label>{{ 'plans.duplicate.searchPlaceholder' | translate }}</mat-label>
-        <input
-          matInput
+      <app-form-field [label]="'plans.duplicate.searchPlaceholder' | translate">
+  <input
           [ngModel]="searchQuery()"
           (ngModelChange)="searchQuery.set($event)"
           type="text"
         />
-      </mat-form-field>
+</app-form-field>
 
       <button mat-stroked-button routerLink="/plans">
         {{ 'plans.duplicate.dialog.cancel' | translate }}

--- a/frontend/src/app/features/plans/plan-duplicate.component.ts
+++ b/frontend/src/app/features/plans/plan-duplicate.component.ts
@@ -18,6 +18,7 @@ import { ViewScopeToggleComponent, ViewScope } from '../../shared/components/vie
 import { AdminService } from '../../core/services/admin.service';
 import { AuthService } from '../../core/services/auth.service';
 import { AdminPlan, AdminSite } from '../../core/models/admin.model';
+import { FormFieldComponent } from '../../shared/components/form-field/form-field.component';
 import {
   DuplicatePlanDialogComponent,
   DuplicatePlanDialogData,
@@ -42,6 +43,7 @@ import {
     TranslateModule,
     HeaderComponent,
     ViewScopeToggleComponent,
+    FormFieldComponent,
   ],
   templateUrl: './plan-duplicate.component.html',
   styleUrl: './plan-duplicate.component.scss',

--- a/frontend/src/app/features/plans/plans-list.component.html
+++ b/frontend/src/app/features/plans/plans-list.component.html
@@ -104,15 +104,13 @@
       <section class="content-section my-plans-section">
         <!-- Toolbar: Recherche + Anciennes versions -->
         <div class="toolbar">
-          <div class="search-box">
-            <i class="fi fi-rr-search"></i>
-            <input
-              type="text"
-              [placeholder]="'plans.list.search' | translate"
-              (input)="onMyPlansSearch($event)"
-              data-testid="plans-search-input"
-            />
-          </div>
+          <app-search-bar
+            [value]="myPlansSearchQuery()"
+            [placeholder]="'plans.list.search' | translate"
+            [ariaLabel]="'plans.list.search' | translate"
+            (valueChange)="myPlansSearchQuery.set($event)"
+            data-testid="plans-search-input">
+          </app-search-bar>
           <button class="btn-link" (click)="toggleOldVersions()" [class.active]="showOldVersions()">
             @if (showOldVersions()) {
               <span>{{ 'plans.list.hideOldVersions' | translate }}</span>
@@ -354,19 +352,12 @@
         <p class="section-description">{{ 'plans.requestAccess.description' | translate }}</p>
 
         <!-- Barre de recherche -->
-        <div class="search-bar">
-          <mat-form-field appearance="outline" class="search-field">
-            <mat-icon matPrefix class="search-icon">
-              <i class="fi fi-rr-search"></i>
-            </mat-icon>
-            <input
-              matInput
-              type="text"
-              [placeholder]="'plans.requestAccess.searchPlaceholder' | translate"
-              (input)="onSearch($event)"
-            />
-          </mat-form-field>
-        </div>
+        <app-search-bar
+          [value]="searchQuery()"
+          [placeholder]="'plans.requestAccess.searchPlaceholder' | translate"
+          [ariaLabel]="'plans.requestAccess.searchPlaceholder' | translate"
+          (valueChange)="searchQuery.set($event)">
+        </app-search-bar>
 
         @if (otherPlans().length === 0) {
           <div class="empty-state empty-state--small">

--- a/frontend/src/app/features/plans/plans-list.component.ts
+++ b/frontend/src/app/features/plans/plans-list.component.ts
@@ -22,6 +22,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { forkJoin, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { HeaderComponent } from '../../shared/components/header/header.component';
+import { SearchBarComponent } from '../../shared/components/search-bar/search-bar.component';
 import { PlanGaugeComponent, GaugeStatus } from '../../shared/components/plan-gauge/plan-gauge.component';
 import { ViewScopeToggleComponent, ViewScope } from '../../shared/components/view-scope-toggle/view-scope-toggle.component';
 import { AdminService } from '../../core/services/admin.service';
@@ -75,7 +76,8 @@ interface PlanWithAccess extends AdminPlan {
     TranslateModule,
     HeaderComponent,
     PlanGaugeComponent,
-    ViewScopeToggleComponent
+    ViewScopeToggleComponent,
+    SearchBarComponent,
   ],
   templateUrl: './plans-list.component.html',
   styleUrl: './plans-list.component.scss'

--- a/frontend/src/app/features/profile/profile.component.html
+++ b/frontend/src/app/features/profile/profile.component.html
@@ -50,7 +50,7 @@
                   </button>
                 } @else {
                   <div class="identifiant-edit">
-                    <mat-form-field appearance="outline" class="identifiant-input-field">
+                    <mat-form-field appearance="outline" class="identifiant-input-field app-mat-form-field">
                       <input
                         matInput
                         type="text"

--- a/frontend/src/app/features/sites/site-detail.component.html
+++ b/frontend/src/app/features/sites/site-detail.component.html
@@ -224,23 +224,17 @@
               } @else {
                 <div class="users-list">
                   @for (ua of siteUsers(); track ua.user.id_role) {
-                    <div class="user-card">
-                      <div class="user-avatar">
-                        <i class="fi fi-rr-user"></i>
-                      </div>
-                      <div class="user-info">
-                        <span class="user-name">{{ getUserDisplayName(ua.user) }}</span>
-                        <span class="user-email">{{ ua.user.email }}</span>
-                        @if (ua.user.organisme) {
-                          <span class="user-org">{{ ua.user.organisme }}</span>
-                        }
-                      </div>
-                      <div class="user-role">
-                        <mat-chip [class]="getUserRoleClass(ua)">
-                          {{ getUserRoleLabel(ua) }}
-                        </mat-chip>
-                      </div>
-                    </div>
+                    <app-entity-tile
+                      icon="fi-rr-user"
+                      [name]="getUserDisplayName(ua.user)"
+                      [subtitle]="ua.user.email">
+                      @if (ua.user.organisme) {
+                        <span class="user-org">{{ ua.user.organisme }}</span>
+                      }
+                      <span tileAction class="user-role-tag" [class]="getUserRoleClass(ua)">
+                        {{ getUserRoleLabel(ua) }}
+                      </span>
+                    </app-entity-tile>
                   }
                 </div>
               }

--- a/frontend/src/app/features/sites/site-detail.component.html
+++ b/frontend/src/app/features/sites/site-detail.component.html
@@ -112,24 +112,16 @@
 
       <!-- Contenu (droite) -->
       <div class="content-column">
-        <!-- Menu sidebar (visuel) -->
-        <nav class="sidebar-menu">
-          @for (item of menuItems; track item.id) {
-            <button
-              class="sidebar-menu-item"
-              [class.active]="activeMenuItem() === item.id"
-              (click)="setActiveMenuItem(item.id)">
-              <i class="fi {{ item.icon }}"></i>
-              <span>{{ item.label | translate }}</span>
-            </button>
-          }
-        </nav>
+        <!-- Navigation interne par ancres (#304) -->
+        <app-anchor-nav
+          class="site-detail-anchor-nav"
+          [items]="anchorNavItems"
+          [activeId]="activeAnchorId()"
+          (itemClick)="onAnchorClick($event)">
+        </app-anchor-nav>
 
-        <!-- Contenu selon menu actif -->
         <div class="content-panel">
-          <!-- Vue d'ensemble -->
-          @if (activeMenuItem() === 'overview' || activeMenuItem() === 'info') {
-            <section class="info-section">
+          <section id="site-info" class="info-section">
               <h2 class="section-title">
                 <i class="fi fi-rr-info"></i>
                 {{ 'sites.detail.info' | translate }}
@@ -149,11 +141,9 @@
                 }
               </div>
             </section>
-          }
 
-          <!-- Organismes gestionnaires -->
-          @if (activeMenuItem() === 'overview' || activeMenuItem() === 'organismes') {
-            <section class="organismes-section">
+            <!-- Organismes gestionnaires -->
+            <section id="site-organismes" class="organismes-section">
               <div class="section-header">
                 <h2 class="section-title">
                   <i class="fi fi-rr-building"></i>
@@ -206,11 +196,9 @@
                 </div>
               }
             </section>
-          }
 
-          <!-- Utilisateurs du site -->
-          @if (activeMenuItem() === 'overview' || activeMenuItem() === 'users') {
-            <section class="users-section">
+            <!-- Utilisateurs du site -->
+            <section id="site-users" class="users-section">
               <div class="section-header">
                 <h2 class="section-title">
                   <i class="fi fi-rr-users"></i>
@@ -257,11 +245,9 @@
                 </div>
               }
             </section>
-          }
 
-          <!-- Plans de gestion -->
-          @if (activeMenuItem() === 'overview' || activeMenuItem() === 'plans') {
-            <section class="plans-section">
+            <!-- Plans de gestion -->
+            <section id="site-plans" class="plans-section">
               <div class="section-header">
                 <h2 class="section-title">
                   <i class="fi fi-rr-document"></i>
@@ -325,7 +311,6 @@
                 </div>
               }
             </section>
-          }
 
         </div>
       </div>

--- a/frontend/src/app/features/sites/site-detail.component.scss
+++ b/frontend/src/app/features/sites/site-detail.component.scss
@@ -68,15 +68,12 @@ h1 { @include sites-h1; }
 }
 .btn-pending { background-color: $gray-light; border: none; color: $gray-dark; cursor: default; }
 
-// Sidebar menu
-.sidebar-menu { display: flex; flex-wrap: wrap; gap: $spacing-xs; margin-bottom: $spacing-lg; padding-bottom: $spacing-md; border-bottom: 1px solid $gray-light; }
-.sidebar-menu-item {
-  @include sites-btn-pill;
-  padding: $spacing-xs $spacing-md; background-color: $white;
-  border: 1px solid $gray-light; font-size: $font-size-small; color: $gray-dark;
-  i { font-size: 13px; }
-  &:hover { border-color: $primary-color; color: $primary-color; }
-  &.active { background-color: $primary-color; border-color: $primary-color; color: $white; }
+// Navigation interne par ancres (#304)
+.site-detail-anchor-nav {
+  display: block;
+  margin-bottom: $spacing-lg;
+  padding-bottom: $spacing-md;
+  border-bottom: 1px solid $gray-light;
 }
 
 // Subsection title
@@ -199,12 +196,10 @@ h1 { @include sites-h1; }
   @include sites-responsive-tablet;
   .title-section { flex-direction: column; gap: $spacing-md; }
   .breadcrumb { flex-wrap: wrap; }
-  .sidebar-menu { justify-content: center; }
 }
 @media (max-width: $breakpoint-mobile) {
   @include sites-responsive-mobile;
   .btn-back { padding: 8px 14px; font-size: $font-size-small; }
-  .sidebar-menu-item { padding: $spacing-xs $spacing-sm; font-size: 11px; }
   .section-title { font-size: $font-size-base; }
   .info-item { padding: $spacing-sm; }
   .info-icon { width: 29px; height: 29px; i { font-size: 13px; } }

--- a/frontend/src/app/features/sites/site-detail.component.spec.ts
+++ b/frontend/src/app/features/sites/site-detail.component.spec.ts
@@ -518,29 +518,29 @@ describe('SiteDetailComponent', () => {
 
   // ==================== SIDEBAR MENU ====================
 
-  describe('Sidebar Menu', () => {
+  describe('Anchor Navigation (#304)', () => {
     beforeEach(fakeAsync(() => {
       fixture.detectChanges();
       tick();
     }));
 
-    it('should have menu items defined', () => {
-      expect(component.menuItems).toHaveLength(5);
-      expect(component.menuItems.map(m => m.id)).toEqual([
-        'overview', 'info', 'organismes', 'users', 'plans'
+    it('should have anchor nav items defined', () => {
+      expect(component.anchorNavItems).toHaveLength(4);
+      expect(component.anchorNavItems.map(m => m.id)).toEqual([
+        'site-info', 'site-organismes', 'site-users', 'site-plans'
       ]);
     });
 
-    it('should set default active menu item to overview', () => {
-      expect(component.activeMenuItem()).toBe('overview');
+    it('should set default active anchor to site-info', () => {
+      expect(component.activeAnchorId()).toBe('site-info');
     });
 
-    it('should change active menu item', () => {
-      component.setActiveMenuItem('users');
-      expect(component.activeMenuItem()).toBe('users');
+    it('should change active anchor on click', () => {
+      component.onAnchorClick({ id: 'site-users', label: 'users' });
+      expect(component.activeAnchorId()).toBe('site-users');
 
-      component.setActiveMenuItem('plans');
-      expect(component.activeMenuItem()).toBe('plans');
+      component.onAnchorClick({ id: 'site-plans', label: 'plans' });
+      expect(component.activeAnchorId()).toBe('site-plans');
     });
   });
 

--- a/frontend/src/app/features/sites/site-detail.component.ts
+++ b/frontend/src/app/features/sites/site-detail.component.ts
@@ -14,6 +14,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { AnchorNavComponent, AnchorNavItem } from '../../shared/components/anchor-nav/anchor-nav.component';
+import { EntityTileComponent } from '../../shared/components/entity-tile/entity-tile.component';
 import { forkJoin, of } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 
@@ -72,6 +73,7 @@ interface SiteUserAssignment {
     LeafletMapComponent,
     SiteTypeDisplayPipe,
     AnchorNavComponent,
+    EntityTileComponent,
   ],
   templateUrl: './site-detail.component.html',
   styleUrl: './site-detail.component.scss'

--- a/frontend/src/app/features/sites/site-detail.component.ts
+++ b/frontend/src/app/features/sites/site-detail.component.ts
@@ -12,8 +12,8 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatTabsModule } from '@angular/material/tabs';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { AnchorNavComponent, AnchorNavItem } from '../../shared/components/anchor-nav/anchor-nav.component';
 import { forkJoin, of } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 
@@ -52,11 +52,6 @@ interface SiteUserAssignment {
   conservateur: boolean;
 }
 
-interface MenuItem {
-  id: string;
-  label: string;
-  icon: string;
-}
 
 @Component({
   selector: 'app-site-detail',
@@ -71,12 +66,12 @@ interface MenuItem {
     MatSnackBarModule,
     MatIconModule,
     MatTooltipModule,
-    MatTabsModule,
     MatDialogModule,
     TranslateModule,
     HeaderComponent,
     LeafletMapComponent,
-    SiteTypeDisplayPipe
+    SiteTypeDisplayPipe,
+    AnchorNavComponent,
   ],
   templateUrl: './site-detail.component.html',
   styleUrl: './site-detail.component.scss'
@@ -101,15 +96,15 @@ export class SiteDetailComponent implements OnInit {
   readonly hasPendingReferentRequest = signal(false);
   readonly pendingPlanRequests = signal<ValidationRequestListItem[]>([]);
 
-  // Menu sidebar (visuel uniquement)
-  readonly menuItems: MenuItem[] = [
-    { id: 'overview', label: 'sites.detail.menu.overview', icon: 'fi-rr-eye' },
-    { id: 'info', label: 'sites.detail.menu.info', icon: 'fi-rr-info' },
-    { id: 'organismes', label: 'sites.detail.menu.organismes', icon: 'fi-rr-building' },
-    { id: 'users', label: 'sites.detail.menu.users', icon: 'fi-rr-users' },
-    { id: 'plans', label: 'sites.detail.menu.plans', icon: 'fi-rr-document' }
+  // Navigation interne par ancres (#304 — choix design : option 2 boutons tertiaires)
+  // Toutes les sections sont toujours visibles ; les ancres scrollent vers la section.
+  readonly anchorNavItems: AnchorNavItem[] = [
+    { id: 'site-info', label: 'sites.detail.menu.info' },
+    { id: 'site-organismes', label: 'sites.detail.menu.organismes' },
+    { id: 'site-users', label: 'sites.detail.menu.users' },
+    { id: 'site-plans', label: 'sites.detail.menu.plans' },
   ];
-  readonly activeMenuItem = signal<string>('overview');
+  readonly activeAnchorId = signal<string>('site-info');
 
   // GeoJSON pour la carte
   readonly mapGeoJSON = computed(() => {
@@ -213,10 +208,10 @@ export class SiteDetailComponent implements OnInit {
   }
 
   /**
-   * Change l'element du menu actif (visuel uniquement).
+   * Mise à jour de l'ancre active (visuel uniquement, scroll géré par AnchorNav).
    */
-  setActiveMenuItem(itemId: string): void {
-    this.activeMenuItem.set(itemId);
+  onAnchorClick(item: AnchorNavItem): void {
+    this.activeAnchorId.set(item.id);
   }
 
   /**

--- a/frontend/src/app/features/sites/sites-list.component.html
+++ b/frontend/src/app/features/sites/sites-list.component.html
@@ -104,20 +104,13 @@
 
             <!-- Barre de recherche -->
             @if (scopedSites().length > 0) {
-              <div class="search-bar">
-                <i class="fi fi-rr-search search-icon"></i>
-                <input
-                  type="text"
-                  class="search-input"
-                  [value]="searchTerm()"
-                  (input)="onSearchChange($event)"
-                  [placeholder]="'sites.mySites.searchPlaceholder' | translate">
-                @if (searchTerm()) {
-                  <button class="search-clear" (click)="clearSearch()">
-                    <i class="fi fi-rr-cross-small"></i>
-                  </button>
-                }
-              </div>
+              <app-search-bar
+                [value]="searchTerm()"
+                [placeholder]="'sites.mySites.searchPlaceholder' | translate"
+                [ariaLabel]="'sites.mySites.searchPlaceholder' | translate"
+                (valueChange)="searchTerm.set($event)"
+                (cleared)="clearSearch()">
+              </app-search-bar>
             }
           </div>
 

--- a/frontend/src/app/features/sites/sites-list.component.ts
+++ b/frontend/src/app/features/sites/sites-list.component.ts
@@ -32,6 +32,7 @@ import { SiteFormModalComponent, SiteFormModalData, SiteFormModalResult } from '
 import { FindOrCreateSiteModalComponent } from '../../shared/components/modals/find-or-create-site-modal/find-or-create-site-modal.component';
 import { BulkSiteImportModalComponent, BulkSiteImportModalResult } from '../../shared/components/modals/bulk-site-import-modal/bulk-site-import-modal.component';
 import { HeaderComponent } from '../../shared/components/header/header.component';
+import { SearchBarComponent } from '../../shared/components/search-bar/search-bar.component';
 import { LeafletMapComponent } from '../../shared/components/leaflet-map/leaflet-map.component';
 import { ViewScopeToggleComponent, ViewScope } from '../../shared/components/view-scope-toggle/view-scope-toggle.component';
 import { SiteTypeDisplayPipe } from '../../shared/pipes/site-type-display.pipe';
@@ -77,7 +78,8 @@ interface SiteWithAccess extends SiteWithUsers {
     HeaderComponent,
     LeafletMapComponent,
     ViewScopeToggleComponent,
-    SiteTypeDisplayPipe
+    SiteTypeDisplayPipe,
+    SearchBarComponent,
   ],
   templateUrl: './sites-list.component.html',
   styleUrl: './sites-list.component.scss'

--- a/frontend/src/app/shared/components/accordion/accordion.component.html
+++ b/frontend/src/app/shared/components/accordion/accordion.component.html
@@ -1,0 +1,38 @@
+<section
+  class="app-accordion"
+  [class]="'app-accordion--' + variant + ' app-accordion--' + size"
+  [class.app-accordion--expanded]="expanded"
+  [class.app-accordion--disabled]="disabled">
+  <header
+    class="app-accordion__header"
+    [attr.role]="disabled ? null : 'button'"
+    [attr.tabindex]="disabled ? null : 0"
+    [attr.aria-expanded]="expanded"
+    (click)="toggle()"
+    (keydown.enter)="toggle(); $event.preventDefault()"
+    (keydown.space)="toggle(); $event.preventDefault()">
+    <div class="app-accordion__heading">
+      <span class="app-accordion__icon-slot">
+        <ng-content select="[accordionIcon]"></ng-content>
+      </span>
+      <span class="app-accordion__title">{{ title }}</span>
+    </div>
+    <div class="app-accordion__header-actions" (click)="$event.stopPropagation()">
+      <ng-content select="[accordionActions]"></ng-content>
+      <button
+        type="button"
+        class="app-accordion__toggle"
+        [disabled]="disabled"
+        [attr.aria-label]="expanded ? 'Replier' : 'Déplier'"
+        (click)="toggle(); $event.stopPropagation()">
+        <i class="fi" [class.fi-rr-angle-up]="expanded" [class.fi-rr-angle-down]="!expanded"></i>
+      </button>
+    </div>
+  </header>
+
+  @if (expanded) {
+    <div class="app-accordion__body">
+      <ng-content></ng-content>
+    </div>
+  }
+</section>

--- a/frontend/src/app/shared/components/accordion/accordion.component.scss
+++ b/frontend/src/app/shared/components/accordion/accordion.component.scss
@@ -1,0 +1,194 @@
+@import 'variables';
+
+// Accordion (issue #303)
+
+.app-accordion {
+  display: block;
+  background-color: $white;
+  border-radius: $border-radius-md;
+  border: 1px solid $gray-light;
+  overflow: hidden;
+  font-family: $font-family;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+  &--expanded {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+  }
+
+  // ============================================
+  // HEADER
+  // ============================================
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $spacing-sm;
+    padding: $spacing-sm $spacing-md;
+    cursor: pointer;
+    user-select: none;
+    transition: background-color 0.15s ease;
+    outline: none;
+
+    &:hover {
+      background-color: rgba($primary-color, 0.03);
+    }
+
+    &:focus-visible {
+      background-color: rgba($primary-color, 0.06);
+    }
+  }
+
+  &__heading {
+    display: inline-flex;
+    align-items: center;
+    gap: $spacing-sm;
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__icon-slot {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+
+    &:empty {
+      display: none;
+    }
+
+    i {
+      font-size: 18px;
+      color: $primary-color;
+    }
+  }
+
+  &__title {
+    font-size: $font-size-base;
+    font-weight: $font-weight-bold;
+    color: $primary-color;
+    line-height: 1.3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__header-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+
+  &__toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    color: $primary-color;
+    transition: background-color 0.15s ease;
+
+    &:hover {
+      background-color: rgba($primary-color, 0.1);
+    }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.4;
+    }
+
+    i {
+      font-size: 16px;
+      line-height: 1;
+    }
+  }
+
+  // ============================================
+  // BODY
+  // ============================================
+
+  &__body {
+    padding: $spacing-md;
+    border-top: 1px solid $gray-light;
+    background-color: $white;
+  }
+
+  // ============================================
+  // VARIANTES
+  // ============================================
+
+  // Variante enjeu (terra-cotta) — barre latérale gauche
+  &--enjeu {
+    border-left: 4px solid $secondary-terra-cotta;
+
+    .app-accordion__icon-slot i {
+      color: $secondary-terra-cotta;
+    }
+  }
+
+  &--enjeu.app-accordion--expanded {
+    .app-accordion__body {
+      background-color: rgba($secondary-terra-cotta, 0.04);
+    }
+  }
+
+  // Variante FCR (saumon)
+  &--fcr {
+    border-left: 4px solid $secondary-orange-salmon;
+
+    .app-accordion__icon-slot i {
+      color: $secondary-orange-salmon;
+    }
+  }
+
+  &--fcr.app-accordion--expanded {
+    .app-accordion__body {
+      background-color: rgba($secondary-orange-salmon, 0.05);
+    }
+  }
+
+  // Variante subtle (sans bordures appuyées)
+  &--subtle {
+    border: none;
+    background: transparent;
+
+    .app-accordion__header {
+      padding: $spacing-xs 0;
+    }
+
+    .app-accordion__body {
+      border-top: none;
+      padding: $spacing-sm 0;
+    }
+  }
+
+  // ============================================
+  // TAILLES
+  // ============================================
+
+  &--sm {
+    .app-accordion__header { padding: $spacing-xs $spacing-sm; }
+    .app-accordion__title { font-size: $font-size-small; }
+    .app-accordion__body { padding: $spacing-sm; }
+  }
+
+  &--lg {
+    .app-accordion__header { padding: $spacing-md $spacing-lg; }
+    .app-accordion__title { font-size: $font-size-h4; }
+    .app-accordion__body { padding: $spacing-lg; }
+  }
+
+  // Désactivé
+  &--disabled .app-accordion__header {
+    cursor: default;
+
+    &:hover {
+      background-color: transparent;
+    }
+  }
+}

--- a/frontend/src/app/shared/components/accordion/accordion.component.ts
+++ b/frontend/src/app/shared/components/accordion/accordion.component.ts
@@ -1,0 +1,78 @@
+import { Component, EventEmitter, Input, Output, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export type AccordionVariant = 'default' | 'enjeu' | 'fcr' | 'subtle';
+export type AccordionSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Accordion - Composant accordéon réutilisable (issue #303)
+ *
+ * Bloc collapsible avec header (titre + icône optionnelle + actions) et body projeté.
+ *
+ * - Chevron haut/bas conforme #297 (replié → bas, déplié → haut)
+ * - 4 variantes visuelles : default, enjeu (terra-cotta), fcr (saumon), subtle (gris clair)
+ * - Slots : `[accordionIcon]` (icône à gauche), `[accordionActions]` (boutons à droite), corps par défaut
+ * - Compatible avec contrôle externe (input `expanded`) ou interne (toggle)
+ *
+ * @example Simple (auto-toggle)
+ * <app-accordion title="Détails du protocole">
+ *   <p>Contenu déplié...</p>
+ * </app-accordion>
+ *
+ * @example Pour enjeu (variant + actions)
+ * <app-accordion
+ *   variant="enjeu"
+ *   title="Enjeu 3 : Préservation de la qualité des eaux"
+ *   [expanded]="isOpen()"
+ *   (expandedChange)="isOpen.set($event)">
+ *   <ng-container accordionIcon>
+ *     <i class="fi fi-rr-mountains"></i>
+ *   </ng-container>
+ *   <button accordionActions class="icon-btn-flat" (click)="onEdit()">
+ *     <i class="fi fi-rr-pencil"></i>
+ *   </button>
+ *   <!-- Corps du bloc -->
+ *   <p>Détails de l'enjeu...</p>
+ * </app-accordion>
+ */
+@Component({
+  selector: 'app-accordion',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './accordion.component.html',
+  styleUrl: './accordion.component.scss',
+})
+export class AccordionComponent {
+  /** Titre affiché dans le header */
+  @Input() title: string = '';
+
+  /** Variante visuelle */
+  @Input() variant: AccordionVariant = 'default';
+
+  /** Taille (espacement et tailles d'icônes) */
+  @Input() size: AccordionSize = 'md';
+
+  /** Contrôle externe de l'état déplié (sinon géré en interne) */
+  @Input()
+  get expanded(): boolean {
+    return this.internalExpanded();
+  }
+  set expanded(value: boolean) {
+    this.internalExpanded.set(value);
+  }
+  @Output() expandedChange = new EventEmitter<boolean>();
+
+  /** Désactive le toggle (header non cliquable) */
+  @Input() disabled: boolean = false;
+
+  protected internalExpanded = signal(false);
+
+  toggle(): void {
+    if (this.disabled) {
+      return;
+    }
+    const next = !this.internalExpanded();
+    this.internalExpanded.set(next);
+    this.expandedChange.emit(next);
+  }
+}

--- a/frontend/src/app/shared/components/anchor-nav/anchor-nav.component.html
+++ b/frontend/src/app/shared/components/anchor-nav/anchor-nav.component.html
@@ -1,0 +1,17 @@
+<nav class="app-anchor-nav" aria-label="Navigation interne">
+  @for (item of items; track item.id; let isLast = $last) {
+    <a
+      class="app-anchor-nav__item"
+      [class.app-anchor-nav__item--active]="isActive(item)"
+      [href]="'#' + item.id"
+      (click)="onClick(item, $event)">
+      @if (item.icon) {
+        <i class="fi" [class]="item.icon" aria-hidden="true"></i>
+      }
+      <span>{{ item.label }}</span>
+    </a>
+    @if (!isLast) {
+      <span class="app-anchor-nav__separator" aria-hidden="true">/</span>
+    }
+  }
+</nav>

--- a/frontend/src/app/shared/components/anchor-nav/anchor-nav.component.scss
+++ b/frontend/src/app/shared/components/anchor-nav/anchor-nav.component.scss
@@ -1,0 +1,53 @@
+@import 'variables';
+
+// AnchorNav (issue #304) — boutons tertiaires séparés par `/`
+
+.app-anchor-nav {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px $spacing-xxs;
+  font-family: $font-family;
+
+  &__item {
+    display: inline-flex;
+    align-items: center;
+    gap: $spacing-xxs;
+    padding: $spacing-xxs $spacing-xs;
+    color: $primary-color;
+    text-decoration: none;
+    font-size: $font-size-base;
+    font-weight: $font-weight-regular;
+    line-height: 1.4;
+    border-radius: $border-radius-sm;
+    transition: color 0.15s ease, background-color 0.15s ease;
+
+    i {
+      font-size: 13px;
+      line-height: 1;
+    }
+
+    &:hover {
+      background-color: rgba($primary-color, 0.06);
+      text-decoration: underline;
+      text-underline-offset: 3px;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $primary-color;
+      outline-offset: 2px;
+    }
+
+    &--active {
+      font-weight: $font-weight-bold;
+      text-decoration: underline;
+      text-underline-offset: 3px;
+    }
+  }
+
+  &__separator {
+    color: $gray-dark;
+    user-select: none;
+    line-height: 1.4;
+  }
+}

--- a/frontend/src/app/shared/components/anchor-nav/anchor-nav.component.ts
+++ b/frontend/src/app/shared/components/anchor-nav/anchor-nav.component.ts
@@ -1,0 +1,70 @@
+import { Component, EventEmitter, Input, Output, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export interface AnchorNavItem {
+  /** ID de l'ancre (correspondant à l'id de la section à scroller) */
+  id: string;
+  /** Label affiché */
+  label: string;
+  /** Optionnel : icône Flaticon à gauche du label */
+  icon?: string;
+}
+
+/**
+ * AnchorNav - Navigation interne par ancres (issue #304)
+ *
+ * Boutons tertiaires séparés par `/` qui scrollent dans la page vers une section.
+ * Conçu pour les pages de détail comportant plusieurs sections (Détail site, etc.).
+ *
+ * - Item actif détecté automatiquement via IntersectionObserver (à venir si besoin)
+ * - Au clic : scroll smooth vers la section, émet `itemClick`
+ * - Aspect visuel : 5 boutons tertiaires séparés par `/`, style ancre
+ *
+ * @example
+ * <app-anchor-nav
+ *   [items]="[
+ *     { id: 'overview', label: 'Vue d\'ensemble' },
+ *     { id: 'info', label: 'Informations' },
+ *     { id: 'organismes', label: 'Organismes' },
+ *     { id: 'users', label: 'Utilisateurs' },
+ *     { id: 'plans', label: 'Plans de gestion' }
+ *   ]"
+ *   [activeId]="currentSection()"
+ *   (itemClick)="onScrollTo($event)">
+ * </app-anchor-nav>
+ */
+@Component({
+  selector: 'app-anchor-nav',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './anchor-nav.component.html',
+  styleUrl: './anchor-nav.component.scss',
+})
+export class AnchorNavComponent {
+  /** Liste des sections / ancres */
+  @Input() items: AnchorNavItem[] = [];
+
+  /** ID de l'item actif (mise en évidence visuelle) */
+  @Input() activeId?: string;
+
+  /** Si true (défaut), scroll smooth vers l'ID au clic */
+  @Input() scrollOnClick: boolean = true;
+
+  /** Émis au clic sur un item */
+  @Output() itemClick = new EventEmitter<AnchorNavItem>();
+
+  onClick(item: AnchorNavItem, event: MouseEvent): void {
+    event.preventDefault();
+    if (this.scrollOnClick) {
+      const target = document.getElementById(item.id);
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    }
+    this.itemClick.emit(item);
+  }
+
+  isActive(item: AnchorNavItem): boolean {
+    return this.activeId === item.id;
+  }
+}

--- a/frontend/src/app/shared/components/checkbox/checkbox.component.html
+++ b/frontend/src/app/shared/components/checkbox/checkbox.component.html
@@ -1,0 +1,28 @@
+<label
+  class="app-checkbox"
+  [class.app-checkbox--checked]="checked"
+  [class.app-checkbox--disabled]="disabled"
+  [class.app-checkbox--with-mention]="!!mention"
+  [attr.for]="inputId">
+  <input
+    type="checkbox"
+    class="app-checkbox__input"
+    [id]="inputId"
+    [checked]="checked"
+    [disabled]="disabled"
+    (change)="toggle($event)"
+  />
+  <span class="app-checkbox__box" aria-hidden="true">
+    @if (checked) {
+      <i class="fi fi-rr-check"></i>
+    }
+  </span>
+  <span class="app-checkbox__text">
+    @if (label) {
+      <span class="app-checkbox__label">{{ label }}</span>
+    }
+    @if (mention) {
+      <span class="app-checkbox__mention">{{ mention }}</span>
+    }
+  </span>
+</label>

--- a/frontend/src/app/shared/components/checkbox/checkbox.component.scss
+++ b/frontend/src/app/shared/components/checkbox/checkbox.component.scss
@@ -1,0 +1,106 @@
+@import 'variables';
+
+// Checkbox custom (issue #299)
+// Carré arrondi, sans cercle ripple Material
+
+.app-checkbox {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: $spacing-xs;
+  cursor: pointer;
+  user-select: none;
+  padding: 2px 0;
+  font-family: $font-family;
+
+  // Input natif caché (mais accessible)
+  &__input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  // La case visuelle
+  &__box {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    margin-top: 1px;
+    background-color: $white;
+    border: 1.5px solid $primary-color;
+    border-radius: $border-radius-sm;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+
+    i {
+      color: $white;
+      font-size: 11px;
+      font-weight: 700;
+      line-height: 1;
+    }
+  }
+
+  // Texte (label + mention optionnelle)
+  &__text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  &__label {
+    font-size: $font-size-base;
+    font-weight: $font-weight-regular;
+    color: $black;
+    line-height: 1.4;
+  }
+
+  &__mention {
+    font-size: $font-size-small;
+    color: $gray-dark;
+    line-height: 1.4;
+  }
+
+  // ============================================
+  // ÉTATS
+  // ============================================
+
+  // Coché
+  &--checked &__box {
+    background-color: $primary-color;
+    border-color: $primary-color;
+  }
+
+  // Focus (sur l'input invisible)
+  &__input:focus-visible + &__box {
+    box-shadow: 0 0 0 2px rgba($primary-color, 0.25);
+  }
+
+  // Hover (sur le label conteneur)
+  &:not(&--disabled):hover &__box {
+    border-color: darken($primary-color, 8%);
+  }
+
+  // Désactivé
+  &--disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+
+    .app-checkbox__box {
+      border-color: $gray;
+      background-color: $beige;
+    }
+  }
+
+  &--disabled.app-checkbox--checked .app-checkbox__box {
+    background-color: $gray;
+    border-color: $gray;
+  }
+}

--- a/frontend/src/app/shared/components/checkbox/checkbox.component.ts
+++ b/frontend/src/app/shared/components/checkbox/checkbox.component.ts
@@ -1,0 +1,87 @@
+import { Component, EventEmitter, forwardRef, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+/**
+ * Checkbox - Composant checkbox custom (issue #299)
+ *
+ * Remplace `<mat-checkbox>` qui a un cercle ripple non-conforme au kit UI.
+ *
+ * - Carré arrondi 16x16, sans cercle ripple
+ * - Bordure bleu-vert + fond blanc quand non coché
+ * - Fond bleu-vert + icône check blanche quand coché
+ * - Variante avec mention sous le label principal
+ * - Compatible Reactive Forms via ControlValueAccessor
+ *
+ * @example Simple
+ * <app-checkbox [(checked)]="agreed" label="J'accepte les conditions"></app-checkbox>
+ *
+ * @example Avec mention
+ * <app-checkbox [(checked)]="copy" label="Sites associés" mention="Copie les associations site-plan"></app-checkbox>
+ *
+ * @example Avec Reactive Forms
+ * <app-checkbox formControlName="active" label="Site actif"></app-checkbox>
+ */
+@Component({
+  selector: 'app-checkbox',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './checkbox.component.html',
+  styleUrl: './checkbox.component.scss',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => CheckboxComponent),
+      multi: true,
+    },
+  ],
+})
+export class CheckboxComponent implements ControlValueAccessor {
+  /** État coché */
+  @Input() checked: boolean = false;
+  @Output() checkedChange = new EventEmitter<boolean>();
+
+  /** Label principal à côté de la case */
+  @Input() label: string = '';
+
+  /** Texte mention affiché sous le label (variant avec description) */
+  @Input() mention?: string;
+
+  /** Désactive la checkbox */
+  @Input() disabled: boolean = false;
+
+  /** ID unique pour l'association label/input (auto-généré sinon) */
+  @Input() inputId: string = `app-checkbox-${Math.random().toString(36).slice(2, 9)}`;
+
+  /** Callbacks ControlValueAccessor */
+  private onChange: (value: boolean) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  toggle(event?: Event): void {
+    if (this.disabled) {
+      return;
+    }
+    event?.preventDefault();
+    this.checked = !this.checked;
+    this.checkedChange.emit(this.checked);
+    this.onChange(this.checked);
+    this.onTouched();
+  }
+
+  // ControlValueAccessor
+  writeValue(value: boolean): void {
+    this.checked = !!value;
+  }
+
+  registerOnChange(fn: (value: boolean) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+}

--- a/frontend/src/app/shared/components/entity-tile/entity-tile.component.html
+++ b/frontend/src/app/shared/components/entity-tile/entity-tile.component.html
@@ -1,21 +1,43 @@
-<div
-  class="app-entity-tile"
-  [class.app-entity-tile--clickable]="clickable"
-  [attr.role]="clickable ? 'button' : null"
-  [attr.tabindex]="clickable ? 0 : null"
-  (click)="onClick()"
-  (keydown.enter)="onClick()"
-  (keydown.space)="onClick()">
+@if (routerLink && !locked) {
+  <a
+    class="app-entity-tile app-entity-tile--clickable"
+    [routerLink]="routerLink">
+    <ng-container *ngTemplateOutlet="tileContent"></ng-container>
+  </a>
+} @else if (href && !locked) {
+  <a
+    class="app-entity-tile app-entity-tile--clickable"
+    [href]="href">
+    <ng-container *ngTemplateOutlet="tileContent"></ng-container>
+  </a>
+} @else {
+  <div
+    class="app-entity-tile"
+    [class.app-entity-tile--clickable]="isInteractive && !locked"
+    [class.app-entity-tile--locked]="locked"
+    [attr.role]="clickable && !locked ? 'button' : null"
+    [attr.tabindex]="clickable && !locked ? 0 : null"
+    (click)="onClick()"
+    (keydown.enter)="onClick()"
+    (keydown.space)="onClick()">
+    <ng-container *ngTemplateOutlet="tileContent"></ng-container>
+  </div>
+}
+
+<ng-template #tileContent>
   <div class="app-entity-tile__icon">
-    <i class="fi" [class]="icon" aria-hidden="true"></i>
+    <i class="fi" [class]="locked ? 'fi-rr-lock' : icon" aria-hidden="true"></i>
   </div>
   <div class="app-entity-tile__info">
     <span class="app-entity-tile__name">{{ name }}</span>
     @if (subtitle) {
       <span class="app-entity-tile__subtitle">{{ subtitle }}</span>
     }
+    <span class="app-entity-tile__body">
+      <ng-content></ng-content>
+    </span>
   </div>
   <div class="app-entity-tile__action">
     <ng-content select="[tileAction]"></ng-content>
   </div>
-</div>
+</ng-template>

--- a/frontend/src/app/shared/components/entity-tile/entity-tile.component.html
+++ b/frontend/src/app/shared/components/entity-tile/entity-tile.component.html
@@ -1,0 +1,21 @@
+<div
+  class="app-entity-tile"
+  [class.app-entity-tile--clickable]="clickable"
+  [attr.role]="clickable ? 'button' : null"
+  [attr.tabindex]="clickable ? 0 : null"
+  (click)="onClick()"
+  (keydown.enter)="onClick()"
+  (keydown.space)="onClick()">
+  <div class="app-entity-tile__icon">
+    <i class="fi" [class]="icon" aria-hidden="true"></i>
+  </div>
+  <div class="app-entity-tile__info">
+    <span class="app-entity-tile__name">{{ name }}</span>
+    @if (subtitle) {
+      <span class="app-entity-tile__subtitle">{{ subtitle }}</span>
+    }
+  </div>
+  <div class="app-entity-tile__action">
+    <ng-content select="[tileAction]"></ng-content>
+  </div>
+</div>

--- a/frontend/src/app/shared/components/entity-tile/entity-tile.component.scss
+++ b/frontend/src/app/shared/components/entity-tile/entity-tile.component.scss
@@ -1,0 +1,83 @@
+@import 'variables';
+
+// EntityTile (issue #302)
+
+.app-entity-tile {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  padding: $spacing-sm $spacing-md;
+  background-color: $gray-lighter; // background tableau kit UI
+  border-radius: $border-radius-md;
+  font-family: $font-family;
+  transition: background-color 0.15s ease;
+
+  &__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    background-color: $white;
+    border-radius: 50%;
+    flex-shrink: 0;
+
+    i {
+      font-size: 16px;
+      color: $primary-color;
+    }
+  }
+
+  &__info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__name {
+    font-size: $font-size-base;
+    font-weight: $font-weight-semibold;
+    color: $black;
+    line-height: 1.3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__subtitle {
+    font-size: $font-size-small;
+    color: $gray-dark;
+    line-height: 1.3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__action {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: $spacing-xs;
+
+    // Si pas de contenu projeté, ne pas réserver d'espace
+    &:empty {
+      display: none;
+    }
+  }
+
+  // Variante cliquable
+  &--clickable {
+    cursor: pointer;
+
+    &:hover {
+      background-color: darken($gray-lighter, 4%);
+    }
+
+    &:focus-visible {
+      outline: 2px solid $primary-color;
+      outline-offset: 2px;
+    }
+  }
+}

--- a/frontend/src/app/shared/components/entity-tile/entity-tile.component.scss
+++ b/frontend/src/app/shared/components/entity-tile/entity-tile.component.scss
@@ -10,6 +10,8 @@
   background-color: $gray-lighter; // background tableau kit UI
   border-radius: $border-radius-md;
   font-family: $font-family;
+  text-decoration: none;
+  color: inherit;
   transition: background-color 0.15s ease;
 
   &__icon {
@@ -78,6 +80,25 @@
     &:focus-visible {
       outline: 2px solid $primary-color;
       outline-offset: 2px;
+    }
+  }
+
+  // Variante verrouillée (site sans accès)
+  &--locked {
+    opacity: 0.85;
+
+    .app-entity-tile__icon i {
+      color: $gray-dark;
+    }
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-xxs;
+
+    &:empty {
+      display: none;
     }
   }
 }

--- a/frontend/src/app/shared/components/entity-tile/entity-tile.component.ts
+++ b/frontend/src/app/shared/components/entity-tile/entity-tile.component.ts
@@ -1,0 +1,62 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+/**
+ * EntityTile - Tuile compacte pour site / utilisateur / organisme (issue #302)
+ *
+ * Utilisée dans :
+ * - Vue d'ensemble plan (sections Sites + Utilisateurs)
+ * - Modales Gérer sites / utilisateurs
+ *
+ * - Icône à gauche (Flaticon class)
+ * - Nom (titre) + sous-info (organisme, email…)
+ * - Action ou tag à droite (slot via `<ng-content select="[tileAction]">`)
+ * - Pas de hover ni cursor si non cliquable
+ *
+ * @example Site
+ * <app-entity-tile
+ *   icon="fi-rr-marker"
+ *   name="Réserve Naturelle du Lac de Remoray"
+ *   subtitle="Réserves Naturelles de France">
+ *   <button tileAction class="link-default">Demander l'accès</button>
+ * </app-entity-tile>
+ *
+ * @example Utilisateur cliquable
+ * <app-entity-tile
+ *   icon="fi-rr-user"
+ *   name="Marie Dupont"
+ *   subtitle="admin.rnf@test.fr"
+ *   [clickable]="true"
+ *   (click)="goToUser()">
+ *   <app-tag tileAction variant="warning" label="Référent" />
+ * </app-entity-tile>
+ */
+@Component({
+  selector: 'app-entity-tile',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './entity-tile.component.html',
+  styleUrl: './entity-tile.component.scss',
+})
+export class EntityTileComponent {
+  /** Classe Flaticon pour l'icône à gauche (ex: 'fi-rr-marker') */
+  @Input() icon: string = 'fi-rr-document';
+
+  /** Nom principal (ligne 1, bold) */
+  @Input() name: string = '';
+
+  /** Sous-info (ligne 2, gris foncé) */
+  @Input() subtitle?: string;
+
+  /** Si true, ajoute curseur et hover */
+  @Input() clickable: boolean = false;
+
+  /** Émis au clic si clickable */
+  @Output() tileClick = new EventEmitter<void>();
+
+  onClick(): void {
+    if (this.clickable) {
+      this.tileClick.emit();
+    }
+  }
+}

--- a/frontend/src/app/shared/components/entity-tile/entity-tile.component.ts
+++ b/frontend/src/app/shared/components/entity-tile/entity-tile.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
 
 /**
  * EntityTile - Tuile compacte pour site / utilisateur / organisme (issue #302)
@@ -34,7 +35,7 @@ import { CommonModule } from '@angular/common';
 @Component({
   selector: 'app-entity-tile',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterLink],
   templateUrl: './entity-tile.component.html',
   styleUrl: './entity-tile.component.scss',
 })
@@ -48,14 +49,27 @@ export class EntityTileComponent {
   /** Sous-info (ligne 2, gris foncé) */
   @Input() subtitle?: string;
 
-  /** Si true, ajoute curseur et hover */
+  /** Si fourni, la tuile devient un lien (navigateur ou Router). Auto-active clickable. */
+  @Input() routerLink?: string | unknown[];
+
+  /** Si fourni (alternative à routerLink), URL externe via <a href> */
+  @Input() href?: string;
+
+  /** État verrouillé (icône lock, opacité réduite) — pour sites sans accès */
+  @Input() locked: boolean = false;
+
+  /** Active curseur + hover sans navigation (utilise tileClick) */
   @Input() clickable: boolean = false;
 
-  /** Émis au clic si clickable */
+  /** Émis au clic (utile sans routerLink ni href) */
   @Output() tileClick = new EventEmitter<void>();
 
+  get isInteractive(): boolean {
+    return this.clickable || !!this.routerLink || !!this.href;
+  }
+
   onClick(): void {
-    if (this.clickable) {
+    if (this.clickable && !this.locked) {
       this.tileClick.emit();
     }
   }

--- a/frontend/src/app/shared/components/form-field/form-field.component.html
+++ b/frontend/src/app/shared/components/form-field/form-field.component.html
@@ -13,7 +13,18 @@
   }
 
   <div class="app-form-field__control">
+    <!-- Slot pour préfixe (icône, bouton à gauche) -->
+    <span class="app-form-field__prefix">
+      <ng-content select="[prefixSlot]"></ng-content>
+    </span>
+
     <ng-content></ng-content>
+
+    <!-- Slot pour suffixe (icône, bouton à droite) -->
+    <span class="app-form-field__suffix-slot">
+      <ng-content select="[suffixSlot]"></ng-content>
+    </span>
+
     @if (suffix) {
       <span class="app-form-field__suffix" aria-hidden="true">{{ suffix }}</span>
     }

--- a/frontend/src/app/shared/components/form-field/form-field.component.html
+++ b/frontend/src/app/shared/components/form-field/form-field.component.html
@@ -1,0 +1,28 @@
+<div class="app-form-field" [class.app-form-field--error]="hasError" [class.app-form-field--with-suffix]="!!suffix">
+  @if (label) {
+    <label class="app-form-field__label" [attr.for]="fieldId">
+      {{ label }}
+      @if (required) {
+        <span class="app-form-field__required" aria-hidden="true">*</span>
+      }
+    </label>
+  }
+
+  @if (helpText) {
+    <p class="app-form-field__help">{{ helpText }}</p>
+  }
+
+  <div class="app-form-field__control">
+    <ng-content></ng-content>
+    @if (suffix) {
+      <span class="app-form-field__suffix" aria-hidden="true">{{ suffix }}</span>
+    }
+  </div>
+
+  @if (error) {
+    <p class="app-form-field__error" role="alert">
+      <i class="fi fi-rr-exclamation" aria-hidden="true"></i>
+      {{ error }}
+    </p>
+  }
+</div>

--- a/frontend/src/app/shared/components/form-field/form-field.component.html
+++ b/frontend/src/app/shared/components/form-field/form-field.component.html
@@ -25,4 +25,9 @@
       {{ error }}
     </p>
   }
+
+  <!-- Slot pour erreurs personnalisées (multi-error avec conditions) -->
+  <div class="app-form-field__error-slot" role="alert">
+    <ng-content select="[errorSlot]"></ng-content>
+  </div>
 </div>

--- a/frontend/src/app/shared/components/form-field/form-field.component.scss
+++ b/frontend/src/app/shared/components/form-field/form-field.component.scss
@@ -123,6 +123,17 @@
     i { font-size: 12px; }
   }
 
+  // Slot pour erreurs personnalisées projetées
+  &__error-slot {
+    color: $error-color;
+    font-size: $font-size-small;
+    line-height: 1.3;
+
+    &:empty {
+      display: none;
+    }
+  }
+
   // État erreur
   &--error &__control {
     :where(input, select, textarea) {

--- a/frontend/src/app/shared/components/form-field/form-field.component.scss
+++ b/frontend/src/app/shared/components/form-field/form-field.component.scss
@@ -105,6 +105,62 @@
     padding-left: $spacing-xxs;
   }
 
+  // Slots prefix / suffix (icônes, boutons projetés)
+  &__prefix,
+  &__suffix-slot {
+    display: inline-flex;
+    align-items: center;
+    color: $gray-dark;
+
+    &:empty {
+      display: none;
+    }
+
+    // Boutons projetés : style compact transparent
+    button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      padding: 0;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      color: $gray-dark;
+      border-radius: 50%;
+
+      &:hover {
+        background-color: rgba($primary-color, 0.08);
+        color: $primary-color;
+      }
+
+      i { font-size: 14px; }
+    }
+
+    i.fi {
+      font-size: 14px;
+    }
+  }
+
+  &__prefix {
+    margin-left: $spacing-xs;
+    margin-right: $spacing-xxs;
+
+    &:empty {
+      margin: 0;
+    }
+  }
+
+  &__suffix-slot {
+    margin-right: $spacing-xs;
+    margin-left: $spacing-xxs;
+
+    &:empty {
+      margin: 0;
+    }
+  }
+
   &--with-suffix {
     :where(input) {
       padding-right: $spacing-xl;

--- a/frontend/src/app/shared/components/form-field/form-field.component.scss
+++ b/frontend/src/app/shared/components/form-field/form-field.component.scss
@@ -1,0 +1,136 @@
+@import 'variables';
+
+// FormField compact (issue #300)
+// Label au-dessus du champ, hauteur réduite vs Material
+
+.app-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-family: $font-family;
+  width: 100%;
+
+  &__label {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    font-size: $font-size-small;
+    font-weight: $font-weight-semibold;
+    color: $black;
+    line-height: 1.3;
+  }
+
+  &__required {
+    color: $error-color;
+    font-weight: $font-weight-bold;
+  }
+
+  &__help {
+    margin: 0;
+    font-size: 12px;
+    color: $gray-dark;
+    line-height: 1.3;
+  }
+
+  &__control {
+    position: relative;
+    display: flex;
+    align-items: center;
+
+    // Style sur les inputs / selects / textareas projetés
+    :where(input, select, textarea) {
+      flex: 1;
+      min-width: 0;
+      padding: $spacing-xs $spacing-sm;
+      background-color: $white;
+      border: 1px solid $gray-light;
+      border-radius: $border-radius-sm;
+      font-family: $font-family;
+      font-size: $font-size-base;
+      color: $black;
+      line-height: 1.4;
+      transition: border-color 0.15s ease, box-shadow 0.15s ease;
+      outline: none;
+      min-height: 38px;
+
+      &::placeholder {
+        color: $gray-dark;
+        opacity: 0.6;
+      }
+
+      &:hover:not(:disabled):not(:focus) {
+        border-color: $gray;
+      }
+
+      &:focus,
+      &:focus-visible {
+        border-color: $primary-color;
+        box-shadow: 0 0 0 2px rgba($primary-color, 0.12);
+      }
+
+      &:disabled {
+        background-color: $beige;
+        color: $gray-dark;
+        cursor: not-allowed;
+      }
+    }
+
+    :where(textarea) {
+      resize: vertical;
+      min-height: 70px;
+      padding: $spacing-sm;
+      font-family: $font-family;
+    }
+
+    :where(select) {
+      cursor: pointer;
+      appearance: none;
+      padding-right: $spacing-xl;
+      background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%23746F6E' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right $spacing-sm center;
+      background-size: 12px;
+    }
+  }
+
+  &__suffix {
+    position: absolute;
+    right: $spacing-sm;
+    top: 50%;
+    transform: translateY(-50%);
+    color: $gray-dark;
+    font-size: $font-size-small;
+    pointer-events: none;
+    background-color: $white;
+    padding-left: $spacing-xxs;
+  }
+
+  &--with-suffix {
+    :where(input) {
+      padding-right: $spacing-xl;
+    }
+  }
+
+  &__error {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin: 0;
+    font-size: $font-size-small;
+    color: $error-color;
+    line-height: 1.3;
+
+    i { font-size: 12px; }
+  }
+
+  // État erreur
+  &--error &__control {
+    :where(input, select, textarea) {
+      border-color: $error-color;
+
+      &:focus, &:focus-visible {
+        box-shadow: 0 0 0 2px rgba($error-color, 0.15);
+      }
+    }
+  }
+}

--- a/frontend/src/app/shared/components/form-field/form-field.component.ts
+++ b/frontend/src/app/shared/components/form-field/form-field.component.ts
@@ -1,0 +1,59 @@
+import { Component, ContentChild, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NgControl } from '@angular/forms';
+
+/**
+ * FormField - Wrapper compact pour champs de formulaire (issue #300)
+ *
+ * Style "label au-dessus du champ" (vs Material Design qui place le label dans le champ).
+ * Beaucoup plus dense pour les applications métier avec beaucoup de champs.
+ *
+ * Le composant est un wrapper visuel : il fournit la structure label + helpText + input + erreur,
+ * mais le contrôle de formulaire reste dans le `<input>`, `<textarea>` ou `<select>` projeté.
+ *
+ * @example Basique
+ * <app-form-field label="Nom du site" required>
+ *   <input type="text" formControlName="name" />
+ * </app-form-field>
+ *
+ * @example Avec aide et erreur
+ * <app-form-field
+ *   label="Surface (ha)"
+ *   helpText="Saisissez un nombre entier"
+ *   [error]="form.controls.surface.touched && form.controls.surface.errors?.['min'] ? 'La surface doit être ≥ 0' : null">
+ *   <input type="number" formControlName="surface" min="0" />
+ * </app-form-field>
+ */
+@Component({
+  selector: 'app-form-field',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './form-field.component.html',
+  styleUrl: './form-field.component.scss',
+})
+export class FormFieldComponent {
+  /** Label affiché au-dessus du champ */
+  @Input() label: string = '';
+
+  /** Marque le champ comme requis (ajoute l'astérisque rouge) */
+  @Input() required: boolean = false;
+
+  /** Texte d'aide affiché ENTRE le label et le champ (accessibilité) */
+  @Input() helpText?: string;
+
+  /** Message d'erreur — quand renseigné, le champ passe en état erreur */
+  @Input() error?: string | null;
+
+  /** Suffixe affiché à droite du champ (ex: 'ha', '€', 'j') */
+  @Input() suffix?: string;
+
+  /** ID unique pour l'association label/input (auto-généré sinon) */
+  @Input() fieldId: string = `app-field-${Math.random().toString(36).slice(2, 9)}`;
+
+  /** Détecte le contrôle projeté pour propager focus/error via [class] */
+  @ContentChild(NgControl) protected control?: NgControl;
+
+  get hasError(): boolean {
+    return !!this.error;
+  }
+}

--- a/frontend/src/app/shared/components/habitat-autocomplete/habitat-autocomplete.component.html
+++ b/frontend/src/app/shared/components/habitat-autocomplete/habitat-autocomplete.component.html
@@ -1,5 +1,6 @@
-<mat-form-field appearance="outline" class="habitat-autocomplete-field">
-  <mat-label>{{ label() }}</mat-label>
+<label class="app-mat-label">{{ label() }}</label>
+      <mat-form-field class="app-mat-form-field habitat-autocomplete-field" appearance="outline">>
+  <mat-label></mat-label>
   <input
     matInput
     [formControl]="searchControl"

--- a/frontend/src/app/shared/components/metrique-form/metrique-form.component.html
+++ b/frontend/src/app/shared/components/metrique-form/metrique-form.component.html
@@ -30,8 +30,9 @@
              required>
     </app-form-field>
 
-    <mat-form-field appearance="outline" class="flex-1">
-      <mat-label>{{ 'enjeux.metriques.typeLabel' | translate }}</mat-label>
+    <label class="app-mat-label">{{ 'enjeux.metriques.typeLabel' | translate }}</label>
+      <mat-form-field class="app-mat-form-field flex-1" appearance="outline">>
+      <mat-label></mat-label>
       <mat-select [(ngModel)]="metrique.type_metrique" (selectionChange)="emitChange()">
         @for (opt of typeMetriqueOptions; track trackByOptionId($index, opt)) {
           <mat-option [value]="opt.id_nomenclature">{{ opt.label }}</mat-option>

--- a/frontend/src/app/shared/components/metrique-form/metrique-form.component.html
+++ b/frontend/src/app/shared/components/metrique-form/metrique-form.component.html
@@ -42,23 +42,21 @@
 
   <!-- Ligne 3 : Pondération + État de référence -->
   <div class="row">
-    <mat-form-field appearance="outline" class="flex-1">
-      <mat-label>{{ 'enjeux.metriques.ponderationLabel' | translate }}</mat-label>
-      <input matInput
+    <app-form-field [label]="'enjeux.metriques.ponderationLabel' | translate">
+  <input
              type="number"
              step="0.1"
              min="0"
              [(ngModel)]="metrique.ponderation"
              (ngModelChange)="emitChange()">
-    </mat-form-field>
+</app-form-field>
 
-    <mat-form-field appearance="outline" class="flex-1">
-      <mat-label>{{ 'enjeux.metriques.etatReferenceLabel' | translate }}</mat-label>
-      <input matInput
+    <app-form-field [label]="'enjeux.metriques.etatReferenceLabel' | translate">
+  <input
              type="text"
              [(ngModel)]="metrique.etat_reference"
              (ngModelChange)="emitChange()">
-    </mat-form-field>
+</app-form-field>
   </div>
 
   <!-- #247 : formule interactive. Cliquer sur un nom de bloc le sélectionne ;

--- a/frontend/src/app/shared/components/metrique-form/metrique-form.component.html
+++ b/frontend/src/app/shared/components/metrique-form/metrique-form.component.html
@@ -1,15 +1,15 @@
 <div class="metrique-form">
   <!-- Ligne 1 : Intitulé + bouton supprimer -->
   <div class="row row-with-action">
-    <mat-form-field appearance="outline" class="flex-1">
-      <mat-label>{{ 'enjeux.metriques.nomLabel' | translate }} <span class="required">*</span></mat-label>
-      <input matInput
-             type="text"
+    <app-form-field class="flex-1"
+                    [label]="'enjeux.metriques.nomLabel' | translate"
+                    [required]="true">
+      <input type="text"
              [(ngModel)]="metrique.nom_metrique"
              (ngModelChange)="emitChange()"
              [placeholder]="'enjeux.metriques.nomPlaceholder' | translate"
              required>
-    </mat-form-field>
+    </app-form-field>
     <button type="button"
             class="btn-delete"
             (click)="onMetriqueDelete()"
@@ -21,14 +21,14 @@
 
   <!-- Ligne 2 : Unité + Type de métrique -->
   <div class="row">
-    <mat-form-field appearance="outline" class="flex-1">
-      <mat-label>{{ 'enjeux.metriques.uniteLabel' | translate }} <span class="required">*</span></mat-label>
-      <input matInput
-             type="text"
+    <app-form-field class="flex-1"
+                    [label]="'enjeux.metriques.uniteLabel' | translate"
+                    [required]="true">
+      <input type="text"
              [(ngModel)]="metrique.unite"
              (ngModelChange)="emitChange()"
              required>
-    </mat-form-field>
+    </app-form-field>
 
     <mat-form-field appearance="outline" class="flex-1">
       <mat-label>{{ 'enjeux.metriques.typeLabel' | translate }}</mat-label>

--- a/frontend/src/app/shared/components/metrique-form/metrique-form.component.ts
+++ b/frontend/src/app/shared/components/metrique-form/metrique-form.component.ts
@@ -8,6 +8,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 import { MetriqueFormData, MetriqueScoreBlock } from '../../../core/models/enjeu.model';
 import { MetriqueBlockComponent, ScoreBlockData } from '../metrique-block/metrique-block.component';
+import { FormFieldComponent } from '../form-field/form-field.component';
 
 /**
  * Form complet de saisie d'une métrique numérique (#247 + #208 + design Figma).
@@ -49,6 +50,7 @@ export interface FormulaPart {
     MatFormFieldModule, MatInputModule, MatSelectModule,
     DragDropModule,
     MetriqueBlockComponent,
+    FormFieldComponent,
   ],
   templateUrl: './metrique-form.component.html',
   styleUrl: './metrique-form.component.scss',

--- a/frontend/src/app/shared/components/modals/admin-role-change-modal/admin-role-change-modal.component.html
+++ b/frontend/src/app/shared/components/modals/admin-role-change-modal/admin-role-change-modal.component.html
@@ -31,15 +31,14 @@
     <!-- Justification field -->
     <div class="justification-section">
       <label class="justification-label">{{ 'modals.adminRoleChange.justification.label' | translate }} *</label>
-      <mat-form-field appearance="outline" class="full-width">
+      <app-form-field class="full-width"
+                      [helpText]="'modals.adminRoleChange.justification.hint' | translate:{ count: justification.length }">
         <textarea
-          matInput
           [(ngModel)]="justification"
           [placeholder]="'modals.adminRoleChange.justification.placeholder' | translate"
           rows="3"
         ></textarea>
-        <mat-hint>{{ 'modals.adminRoleChange.justification.hint' | translate:{ count: justification.length } }}</mat-hint>
-      </mat-form-field>
+      </app-form-field>
 
       @if (errorMessage()) {
         <div class="error-message">

--- a/frontend/src/app/shared/components/modals/admin-role-change-modal/admin-role-change-modal.component.ts
+++ b/frontend/src/app/shared/components/modals/admin-role-change-modal/admin-role-change-modal.component.ts
@@ -6,6 +6,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { FormFieldComponent } from '../../form-field/form-field.component';
 
 export type AdminRoleChangeType = 'promotion' | 'demotion';
 
@@ -27,10 +28,9 @@ export interface AdminRoleChangeModalResult {
     CommonModule,
     FormsModule,
     MatDialogModule,
-    MatFormFieldModule,
-    MatInputModule,
     MatButtonModule,
-    TranslateModule
+    TranslateModule,
+    FormFieldComponent,
   ],
   templateUrl: './admin-role-change-modal.component.html',
   styleUrl: './admin-role-change-modal.component.scss'

--- a/frontend/src/app/shared/components/modals/bulk-site-import-modal/bulk-site-import-modal.component.html
+++ b/frontend/src/app/shared/components/modals/bulk-site-import-modal/bulk-site-import-modal.component.html
@@ -4,25 +4,17 @@
 </h2>
 
 <mat-dialog-content>
-  <!-- Stepper header always visible -->
-  <mat-stepper #stepper [linear]="false" [selectedIndex]="currentStep()" (selectionChange)="currentStep.set($event.selectedIndex)">
+  <!-- Stepper (#301) — composant unifié -->
+  <app-stepper
+    class="bulk-import-stepper"
+    [steps]="stepperStepsComputed()"
+    [currentStep]="currentStep()"
+    (stepClick)="onStepClick($event)">
+  </app-stepper>
 
-    <!-- Custom step icons (Uicons Flaticon - Rounded Regular) -->
-    <!-- Per-step custom state icons -->
-    <ng-template matStepperIcon="upload"><i class="fi fi-rr-cloud-upload-alt"></i></ng-template>
-    <ng-template matStepperIcon="mapping"><i class="fi fi-rr-shuffle"></i></ng-template>
-    <ng-template matStepperIcon="preview"><i class="fi fi-rr-eye"></i></ng-template>
-    <ng-template matStepperIcon="results"><i class="fi fi-rr-check"></i></ng-template>
-    <!-- Fallback icons for completed steps (edit = completed+editable, done = completed+non-editable) -->
-    <ng-template matStepperIcon="edit"><i class="fi fi-rr-check"></i></ng-template>
-    <ng-template matStepperIcon="done"><i class="fi fi-rr-check"></i></ng-template>
-    <ng-template matStepperIcon="number"><i class="fi fi-rr-circle-small"></i></ng-template>
-
-    <!-- Step 1: Upload -->
-    <mat-step [completed]="validationResult() !== null" state="upload">
-      <ng-template matStepLabel>{{ 'modals.bulkImport.steps.upload' | translate }}</ng-template>
-
-      <div class="step-content">
+  <!-- Step 1: Upload -->
+  @if (currentStep() === 0) {
+    <div class="step-content">
         <p class="step-description">{{ 'modals.bulkImport.upload.description' | translate }}</p>
 
         <div class="format-info">
@@ -92,14 +84,12 @@
             <i class="fi fi-rr-angle-right"></i>
           </button>
         </div>
-      </div>
-    </mat-step>
+    </div>
+  }
 
-    <!-- Step 2: Mapping -->
-    <mat-step [completed]="currentStep() > 1" state="mapping">
-      <ng-template matStepLabel>{{ 'modals.bulkImport.steps.mapping' | translate }}</ng-template>
-
-      <div class="step-content">
+  <!-- Step 2: Mapping -->
+  @if (currentStep() === 1) {
+    <div class="step-content">
         <p class="step-description">{{ 'modals.bulkImport.mapping.description' | translate }}</p>
 
         <div class="mapping-table-wrapper">
@@ -153,14 +143,12 @@
             </button>
           </div>
         </div>
-      </div>
-    </mat-step>
+    </div>
+  }
 
-    <!-- Step 3: Preview -->
-    <mat-step [completed]="currentStep() > 2" state="preview">
-      <ng-template matStepLabel>{{ 'modals.bulkImport.steps.preview' | translate }}</ng-template>
-
-      <div class="step-content">
+  <!-- Step 3: Preview -->
+  @if (currentStep() === 2) {
+    <div class="step-content">
         <p class="step-description">{{ 'modals.bulkImport.preview.description' | translate }}</p>
 
         <!-- Summary bar -->
@@ -270,14 +258,12 @@
         @if (totalValid() === 0) {
           <p class="no-valid-text">{{ 'modals.bulkImport.preview.noValidSites' | translate }}</p>
         }
-      </div>
-    </mat-step>
+    </div>
+  }
 
-    <!-- Step 4: Results -->
-    <mat-step state="results">
-      <ng-template matStepLabel>{{ 'modals.bulkImport.steps.results' | translate }}</ng-template>
-
-      <div class="step-content">
+  <!-- Step 4: Results -->
+  @if (currentStep() === 3) {
+    <div class="step-content">
         @if (importing()) {
           <div class="import-progress">
             <p>{{ 'modals.bulkImport.results.importing' | translate }}</p>
@@ -340,9 +326,8 @@
             }
           </div>
         }
-      </div>
-    </mat-step>
-  </mat-stepper>
+    </div>
+  }
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">

--- a/frontend/src/app/shared/components/modals/bulk-site-import-modal/bulk-site-import-modal.component.html
+++ b/frontend/src/app/shared/components/modals/bulk-site-import-modal/bulk-site-import-modal.component.html
@@ -106,7 +106,7 @@
                 <tr>
                   <td class="prop-name">{{ prop }}</td>
                   <td>
-                    <mat-form-field appearance="outline" class="mapping-select">
+                    <mat-form-field appearance="outline" class="mapping-select app-mat-form-field">
                       <mat-select [value]="fieldMapping()[prop] || ''"
                                   (selectionChange)="onMappingChange(prop, $event.value)">
                         <mat-option value="">{{ 'modals.bulkImport.mapping.ignore' | translate }}</mat-option>

--- a/frontend/src/app/shared/components/modals/bulk-site-import-modal/bulk-site-import-modal.component.ts
+++ b/frontend/src/app/shared/components/modals/bulk-site-import-modal/bulk-site-import-modal.component.ts
@@ -1,10 +1,9 @@
-import { Component, inject, signal, computed, ViewChild } from '@angular/core';
+import { Component, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
-import { MatStepper, MatStepperModule } from '@angular/material/stepper';
-import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 import { MatButtonModule } from '@angular/material/button';
+import { StepperComponent, StepperStep } from '../../stepper/stepper.component';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTableModule } from '@angular/material/table';
@@ -50,8 +49,8 @@ const TARGET_FIELDS = [
     CommonModule,
     FormsModule,
     MatDialogModule,
-    MatStepperModule,
     MatButtonModule,
+    StepperComponent,
     MatFormFieldModule,
     MatSelectModule,
     MatTableModule,
@@ -65,22 +64,37 @@ const TARGET_FIELDS = [
   ],
   templateUrl: './bulk-site-import-modal.component.html',
   styleUrl: './bulk-site-import-modal.component.scss',
-  providers: [
-    {
-      provide: STEPPER_GLOBAL_OPTIONS,
-      useValue: { displayDefaultIndicatorType: false },
-    },
-  ],
 })
 export class BulkSiteImportModalComponent {
   private readonly dialogRef = inject(MatDialogRef<BulkSiteImportModalComponent>);
   private readonly adminService = inject(AdminService);
   private readonly translate = inject(TranslateService);
 
-  @ViewChild('stepper') stepper!: MatStepper;
-
   // Step state
   readonly currentStep = signal(0);
+
+  // Configuration du stepper (#301)
+  readonly stepperSteps: StepperStep[] = [
+    { id: 0, label: 'Fichier' },
+    { id: 1, label: 'Correspondance' },
+    { id: 2, label: 'Vérification' },
+    { id: 3, label: 'Résultats' },
+  ];
+
+  readonly stepperStepsComputed = computed(() =>
+    this.stepperSteps.map((step, index) => ({
+      ...step,
+      completed: index < this.currentStep(),
+    })),
+  );
+
+  onStepClick(step: StepperStep): void {
+    // Permet de revenir en arrière uniquement (les complétées sont cliquables)
+    const targetIndex = typeof step.id === 'number' ? step.id : 0;
+    if (targetIndex < this.currentStep()) {
+      this.currentStep.set(targetIndex);
+    }
+  }
 
   // Step 1: Upload
   readonly selectedFile = signal<File | null>(null);
@@ -250,13 +264,11 @@ export class BulkSiteImportModalComponent {
   }
 
   stepNext(): void {
-    this.stepper.next();
-    this.currentStep.set(this.stepper.selectedIndex);
+    this.currentStep.update((s) => Math.min(s + 1, this.stepperSteps.length - 1));
   }
 
   stepPrevious(): void {
-    this.stepper.previous();
-    this.currentStep.set(this.stepper.selectedIndex);
+    this.currentStep.update((s) => Math.max(s - 1, 0));
   }
 
   // Step 3: Preview

--- a/frontend/src/app/shared/components/modals/csrpn-step-dialog/csrpn-step-dialog.component.html
+++ b/frontend/src/app/shared/components/modals/csrpn-step-dialog/csrpn-step-dialog.component.html
@@ -39,9 +39,11 @@
     }
 
     @if (showMiParcoursToggle) {
-      <mat-checkbox formControlName="isMiParcours" class="mi-parcours-toggle">
-        {{ 'plans.lifecycle.csrpnStep.miParcoursLabel' | translate }}
-      </mat-checkbox>
+      <app-checkbox
+        formControlName="isMiParcours"
+        class="mi-parcours-toggle"
+        [label]="'plans.lifecycle.csrpnStep.miParcoursLabel' | translate">
+      </app-checkbox>
     }
   </mat-dialog-content>
 

--- a/frontend/src/app/shared/components/modals/csrpn-step-dialog/csrpn-step-dialog.component.html
+++ b/frontend/src/app/shared/components/modals/csrpn-step-dialog/csrpn-step-dialog.component.html
@@ -12,12 +12,11 @@
       @if (data.step === 'arrete') { {{ 'plans.lifecycle.csrpnStep.arreteIntro' | translate }} }
     </p>
 
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>
-        @if (data.step === 'csrpn') { {{ 'plans.lifecycle.csrpnStep.csrpnDateLabel' | translate }} }
+    <label class="app-mat-label">@if (data.step === 'csrpn') { {{ 'plans.lifecycle.csrpnStep.csrpnDateLabel' | translate }} }
         @if (data.step === 'comite') { {{ 'plans.lifecycle.csrpnStep.comiteDateLabel' | translate }} }
-        @if (data.step === 'arrete') { {{ 'plans.lifecycle.csrpnStep.arreteDateLabel' | translate }} }
-      </mat-label>
+        @if (data.step === 'arrete') { {{ 'plans.lifecycle.csrpnStep.arreteDateLabel' | translate }} }</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+      <mat-label></mat-label>
       <input matInput [matDatepicker]="picker" formControlName="date" required>
       <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
       <mat-datepicker #picker></mat-datepicker>

--- a/frontend/src/app/shared/components/modals/csrpn-step-dialog/csrpn-step-dialog.component.html
+++ b/frontend/src/app/shared/components/modals/csrpn-step-dialog/csrpn-step-dialog.component.html
@@ -31,11 +31,13 @@
     }
 
     @if (data.step === 'arrete') {
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'plans.lifecycle.csrpnStep.arreteNumeroLabel' | translate }}</mat-label>
-        <input matInput formControlName="numeroArrete" required>
-        <mat-hint>{{ 'plans.lifecycle.csrpnStep.arreteNumeroHint' | translate }}</mat-hint>
-      </mat-form-field>
+      <app-form-field
+        class="full-width"
+        [label]="'plans.lifecycle.csrpnStep.arreteNumeroLabel' | translate"
+        [required]="true"
+        [helpText]="'plans.lifecycle.csrpnStep.arreteNumeroHint' | translate">
+        <input formControlName="numeroArrete" required>
+      </app-form-field>
     }
 
     @if (showMiParcoursToggle) {

--- a/frontend/src/app/shared/components/modals/csrpn-step-dialog/csrpn-step-dialog.component.ts
+++ b/frontend/src/app/shared/components/modals/csrpn-step-dialog/csrpn-step-dialog.component.ts
@@ -9,6 +9,7 @@ import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { CheckboxComponent } from '../../checkbox/checkbox.component';
+import { FormFieldComponent } from '../../form-field/form-field.component';
 
 /** Type d'étape CSRPN à saisir (#277). */
 export type CsrpnStep = 'csrpn' | 'comite' | 'arrete';
@@ -46,6 +47,7 @@ export interface CsrpnStepDialogResult {
     MatDatepickerModule,
     MatNativeDateModule,
     CheckboxComponent,
+    FormFieldComponent,
     TranslateModule,
   ],
   templateUrl: './csrpn-step-dialog.component.html',

--- a/frontend/src/app/shared/components/modals/csrpn-step-dialog/csrpn-step-dialog.component.ts
+++ b/frontend/src/app/shared/components/modals/csrpn-step-dialog/csrpn-step-dialog.component.ts
@@ -7,8 +7,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import { TranslateModule } from '@ngx-translate/core';
+import { CheckboxComponent } from '../../checkbox/checkbox.component';
 
 /** Type d'étape CSRPN à saisir (#277). */
 export type CsrpnStep = 'csrpn' | 'comite' | 'arrete';
@@ -45,7 +45,7 @@ export interface CsrpnStepDialogResult {
     MatInputModule,
     MatDatepickerModule,
     MatNativeDateModule,
-    MatCheckboxModule,
+    CheckboxComponent,
     TranslateModule,
   ],
   templateUrl: './csrpn-step-dialog.component.html',

--- a/frontend/src/app/shared/components/modals/deactivate-user-modal/deactivate-user-modal.component.html
+++ b/frontend/src/app/shared/components/modals/deactivate-user-modal/deactivate-user-modal.component.html
@@ -24,16 +24,17 @@
 
     <!-- Reason field -->
     <div class="reason-section">
-      <label class="reason-label">{{ 'modals.deactivateUser.reason.label' | translate }} *</label>
-      <mat-form-field appearance="outline" class="full-width">
+      <app-form-field
+        class="full-width"
+        [label]="'modals.deactivateUser.reason.label' | translate"
+        [required]="true"
+        [helpText]="'modals.deactivateUser.reason.hint' | translate:{ count: reason.length }">
         <textarea
-          matInput
           [(ngModel)]="reason"
           [placeholder]="'modals.deactivateUser.reason.placeholder' | translate"
           rows="3"
         ></textarea>
-        <mat-hint>{{ 'modals.deactivateUser.reason.hint' | translate:{ count: reason.length } }}</mat-hint>
-      </mat-form-field>
+      </app-form-field>
 
       @if (errorMessage()) {
         <div class="error-message">

--- a/frontend/src/app/shared/components/modals/deactivate-user-modal/deactivate-user-modal.component.ts
+++ b/frontend/src/app/shared/components/modals/deactivate-user-modal/deactivate-user-modal.component.ts
@@ -2,10 +2,9 @@ import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { FormFieldComponent } from '../../form-field/form-field.component';
 
 export interface DeactivateUserModalData {
   userName: string;
@@ -24,10 +23,9 @@ export interface DeactivateUserModalResult {
     CommonModule,
     FormsModule,
     MatDialogModule,
-    MatFormFieldModule,
-    MatInputModule,
     MatButtonModule,
-    TranslateModule
+    TranslateModule,
+    FormFieldComponent,
   ],
   templateUrl: './deactivate-user-modal.component.html',
   styleUrl: './deactivate-user-modal.component.scss'

--- a/frontend/src/app/shared/components/modals/delete-account-modal/delete-account-modal.component.html
+++ b/frontend/src/app/shared/components/modals/delete-account-modal/delete-account-modal.component.html
@@ -36,17 +36,17 @@
     <span>{{ 'profile.rgpd.dialog.gracePeriod' | translate }}</span>
   </div>
 
-  <mat-form-field appearance="outline" class="full-width">
-    <mat-label>{{ 'profile.rgpd.dialog.confirmLabel' | translate }}</mat-label>
+  <app-form-field
+    class="full-width"
+    [label]="'profile.rgpd.dialog.confirmLabel' | translate"
+    [helpText]="data.userEmail">
     <input
-      matInput
       type="email"
       [(ngModel)]="confirmEmail"
       [placeholder]="'profile.rgpd.dialog.confirmPlaceholder' | translate"
       autocomplete="off"
     />
-    <mat-hint>{{ data.userEmail }}</mat-hint>
-  </mat-form-field>
+  </app-form-field>
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">

--- a/frontend/src/app/shared/components/modals/delete-account-modal/delete-account-modal.component.ts
+++ b/frontend/src/app/shared/components/modals/delete-account-modal/delete-account-modal.component.ts
@@ -2,10 +2,9 @@ import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { TranslateModule } from '@ngx-translate/core';
+import { FormFieldComponent } from '../../form-field/form-field.component';
 
 export interface DeleteAccountModalData {
   userEmail: string;
@@ -22,10 +21,9 @@ export interface DeleteAccountModalResult {
     CommonModule,
     FormsModule,
     MatDialogModule,
-    MatFormFieldModule,
-    MatInputModule,
     MatButtonModule,
-    TranslateModule
+    TranslateModule,
+    FormFieldComponent,
   ],
   templateUrl: './delete-account-modal.component.html',
   styleUrl: './delete-account-modal.component.scss'

--- a/frontend/src/app/shared/components/modals/duplicate-plan-dialog/duplicate-plan-dialog.component.html
+++ b/frontend/src/app/shared/components/modals/duplicate-plan-dialog/duplicate-plan-dialog.component.html
@@ -15,64 +15,48 @@
     </div>
   </div>
 
-  <!-- Copy options -->
+  <!-- Copy options — Composant Checkbox unifié avec mention (#299) -->
   <div class="options-list">
-    <div class="option-item">
-      <mat-checkbox
-        [checked]="copySites()"
-        (change)="copySites.set($event.checked)"
-        color="primary"
-      >
-        {{ 'plans.duplicate.dialog.options.sites' | translate }}
-      </mat-checkbox>
-      <span class="option-description">{{ 'plans.duplicate.dialog.options.sitesDescription' | translate }}</span>
-    </div>
+    <app-checkbox
+      class="option-item"
+      [checked]="copySites()"
+      [label]="'plans.duplicate.dialog.options.sites' | translate"
+      [mention]="'plans.duplicate.dialog.options.sitesDescription' | translate"
+      (checkedChange)="copySites.set($event)">
+    </app-checkbox>
 
-    <div class="option-item">
-      <mat-checkbox
-        [checked]="copyReferents()"
-        (change)="copyReferents.set($event.checked)"
-        color="primary"
-      >
-        {{ 'plans.duplicate.dialog.options.referents' | translate }}
-      </mat-checkbox>
-      <span class="option-description">{{ 'plans.duplicate.dialog.options.referentsDescription' | translate }}</span>
-    </div>
+    <app-checkbox
+      class="option-item"
+      [checked]="copyReferents()"
+      [label]="'plans.duplicate.dialog.options.referents' | translate"
+      [mention]="'plans.duplicate.dialog.options.referentsDescription' | translate"
+      (checkedChange)="copyReferents.set($event)">
+    </app-checkbox>
 
-    <div class="option-item">
-      <mat-checkbox
-        [checked]="copyFichiers()"
-        (change)="copyFichiers.set($event.checked)"
-        color="primary"
-      >
-        {{ 'plans.duplicate.dialog.options.fichiers' | translate }}
-      </mat-checkbox>
-      <span class="option-description">{{ 'plans.duplicate.dialog.options.fichiersDescription' | translate }}</span>
-    </div>
+    <app-checkbox
+      class="option-item"
+      [checked]="copyFichiers()"
+      [label]="'plans.duplicate.dialog.options.fichiers' | translate"
+      [mention]="'plans.duplicate.dialog.options.fichiersDescription' | translate"
+      (checkedChange)="copyFichiers.set($event)">
+    </app-checkbox>
 
-    <div class="option-item">
-      <mat-checkbox
-        [checked]="copyEnjeux()"
-        (change)="onEnjeuxChange($event.checked)"
-        color="primary"
-      >
-        {{ 'plans.duplicate.dialog.options.enjeux' | translate }}
-      </mat-checkbox>
-      <span class="option-description">{{ 'plans.duplicate.dialog.options.enjeuxDescription' | translate }}</span>
-    </div>
+    <app-checkbox
+      class="option-item"
+      [checked]="copyEnjeux()"
+      [label]="'plans.duplicate.dialog.options.enjeux' | translate"
+      [mention]="'plans.duplicate.dialog.options.enjeuxDescription' | translate"
+      (checkedChange)="onEnjeuxChange($event)">
+    </app-checkbox>
 
     <div class="option-item option-nested">
-      <mat-checkbox
+      <app-checkbox
         [checked]="copySubElements()"
-        (change)="copySubElements.set($event.checked)"
+        [label]="'plans.duplicate.dialog.options.subElements' | translate"
+        [mention]="'plans.duplicate.dialog.options.subElementsDescription' | translate"
         [disabled]="subElementsDisabled()"
-        color="primary"
-      >
-        {{ 'plans.duplicate.dialog.options.subElements' | translate }}
-      </mat-checkbox>
-      <span class="option-description">
-        {{ 'plans.duplicate.dialog.options.subElementsDescription' | translate }}
-      </span>
+        (checkedChange)="copySubElements.set($event)">
+      </app-checkbox>
       <span class="option-hint" *ngIf="subElementsDisabled()">
         {{ 'plans.duplicate.dialog.hints.subElementsDisabled' | translate }}
       </span>

--- a/frontend/src/app/shared/components/modals/duplicate-plan-dialog/duplicate-plan-dialog.component.spec.ts
+++ b/frontend/src/app/shared/components/modals/duplicate-plan-dialog/duplicate-plan-dialog.component.spec.ts
@@ -195,7 +195,7 @@ describe('DuplicatePlanDialogComponent', () => {
 
   describe('UI rendering', () => {
     it('should render 5 checkboxes', () => {
-      const checkboxes = fixture.nativeElement.querySelectorAll('mat-checkbox');
+      const checkboxes = fixture.nativeElement.querySelectorAll('app-checkbox');
       expect(checkboxes.length).toBe(5);
     });
 

--- a/frontend/src/app/shared/components/modals/duplicate-plan-dialog/duplicate-plan-dialog.component.ts
+++ b/frontend/src/app/shared/components/modals/duplicate-plan-dialog/duplicate-plan-dialog.component.ts
@@ -2,11 +2,11 @@ import { Component, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslateModule } from '@ngx-translate/core';
 import { FormsModule } from '@angular/forms';
 import { PlanDuplicateOptions } from '../../../../core/models/admin.model';
+import { CheckboxComponent } from '../../checkbox/checkbox.component';
 
 export interface DuplicatePlanDialogData {
   planId: number;
@@ -29,9 +29,9 @@ export interface DuplicatePlanDialogResult {
     FormsModule,
     MatDialogModule,
     MatButtonModule,
-    MatCheckboxModule,
     MatProgressSpinnerModule,
     TranslateModule,
+    CheckboxComponent,
   ],
   templateUrl: './duplicate-plan-dialog.component.html',
   styleUrl: './duplicate-plan-dialog.component.scss',

--- a/frontend/src/app/shared/components/modals/find-or-create-site-modal/find-or-create-site-modal.component.html
+++ b/frontend/src/app/shared/components/modals/find-or-create-site-modal/find-or-create-site-modal.component.html
@@ -195,14 +195,13 @@
                   <!-- Formulaire de demande pleine largeur -->
                   @if (expandedOrgLinkSite() === site.id_site && site.canRequestOrgLink) {
                     <div class="org-link-form">
-                      <mat-form-field appearance="outline" class="justification-field">
-                        <mat-label>{{ 'sites.findOrCreate.orgLinkJustificationLabel' | translate }}</mat-label>
-                        <textarea matInput
+                      <app-form-field [label]="'sites.findOrCreate.orgLinkJustificationLabel' | translate">
+  <textarea
                                   rows="2"
                                   [value]="orgLinkJustification()"
                                   (input)="onOrgLinkJustificationChange($event)"
                                   [placeholder]="'sites.findOrCreate.orgLinkJustificationPlaceholder' | translate"></textarea>
-                      </mat-form-field>
+</app-form-field>
                       <div class="org-link-checkboxes">
                         <app-checkbox
                           [checked]="orgLinkWithAccess()"

--- a/frontend/src/app/shared/components/modals/find-or-create-site-modal/find-or-create-site-modal.component.html
+++ b/frontend/src/app/shared/components/modals/find-or-create-site-modal/find-or-create-site-modal.component.html
@@ -54,15 +54,14 @@
       {{ 'sites.findOrCreate.searchTitle' | translate }}
     </h4>
 
-    <mat-form-field appearance="outline" class="search-field">
-      <mat-label>{{ 'sites.findOrCreate.searchLabel' | translate }}</mat-label>
-      <input matInput
-             type="text"
+    <app-form-field class="search-field"
+                    [label]="'sites.findOrCreate.searchLabel' | translate">
+      <input type="text"
              [value]="searchTerm()"
              (input)="onSearchChange($event)"
              [placeholder]="'sites.findOrCreate.searchPlaceholder' | translate">
-      <i matSuffix class="fi fi-rr-search search-icon"></i>
-    </mat-form-field>
+      <i suffixSlot class="fi fi-rr-search search-icon"></i>
+    </app-form-field>
 
     <p class="search-hint">{{ 'sites.findOrCreate.searchHint' | translate }}</p>
 

--- a/frontend/src/app/shared/components/modals/find-or-create-site-modal/find-or-create-site-modal.component.html
+++ b/frontend/src/app/shared/components/modals/find-or-create-site-modal/find-or-create-site-modal.component.html
@@ -116,12 +116,12 @@
                       </div>
                     } @else if (site.canRequestAccess) {
                       <div class="access-request-options">
-                        <mat-checkbox
+                        <app-checkbox
                           [checked]="isReferentRequest(site)"
-                          (change)="onReferentChange(site, $event.checked)"
-                          class="referent-checkbox">
-                          {{ 'sites.findOrCreate.asReferent' | translate }}
-                        </mat-checkbox>
+                          (checkedChange)="onReferentChange(site, $event)"
+                          class="referent-checkbox"
+                          [label]="'sites.findOrCreate.asReferent' | translate">
+                        </app-checkbox>
                         <button mat-flat-button
                                 color="primary"
                                 class="btn-request-access"
@@ -204,19 +204,19 @@
                                   [placeholder]="'sites.findOrCreate.orgLinkJustificationPlaceholder' | translate"></textarea>
                       </mat-form-field>
                       <div class="org-link-checkboxes">
-                        <mat-checkbox
+                        <app-checkbox
                           [checked]="orgLinkWithAccess()"
-                          (change)="orgLinkWithAccess.set($event.checked)"
-                          class="org-link-access-checkbox">
-                          {{ 'sites.findOrCreate.orgLinkWithAccess' | translate }}
-                        </mat-checkbox>
+                          (checkedChange)="orgLinkWithAccess.set($event)"
+                          class="org-link-access-checkbox"
+                          [label]="'sites.findOrCreate.orgLinkWithAccess' | translate">
+                        </app-checkbox>
                         @if (orgLinkWithAccess()) {
-                          <mat-checkbox
+                          <app-checkbox
                             [checked]="orgLinkAsReferent()"
-                            (change)="orgLinkAsReferent.set($event.checked)"
-                            class="org-link-referent-checkbox">
-                            {{ 'sites.findOrCreate.asReferent' | translate }}
-                          </mat-checkbox>
+                            (checkedChange)="orgLinkAsReferent.set($event)"
+                            class="org-link-referent-checkbox"
+                            [label]="'sites.findOrCreate.asReferent' | translate">
+                          </app-checkbox>
                         }
                       </div>
                       <div class="org-link-form-actions">

--- a/frontend/src/app/shared/components/modals/find-or-create-site-modal/find-or-create-site-modal.component.ts
+++ b/frontend/src/app/shared/components/modals/find-or-create-site-modal/find-or-create-site-modal.component.ts
@@ -17,6 +17,7 @@ import { ValidationService } from '../../../../core/services/validation.service'
 import { AuthService } from '../../../../core/services/auth.service';
 import { AdminSite } from '../../../../core/models/admin.model';
 import { SiteFormModalComponent, SiteFormModalData } from '../site-form-modal/site-form-modal.component';
+import { FormFieldComponent } from '../../form-field/form-field.component';
 
 export interface FindOrCreateSiteModalData {
   // Données optionnelles
@@ -46,7 +47,8 @@ interface SearchableSite extends AdminSite {
     MatProgressSpinnerModule,
     MatDividerModule,
     CheckboxComponent,
-    TranslateModule
+    TranslateModule,
+    FormFieldComponent,
   ],
   templateUrl: './find-or-create-site-modal.component.html',
   styleUrl: './find-or-create-site-modal.component.scss'

--- a/frontend/src/app/shared/components/modals/find-or-create-site-modal/find-or-create-site-modal.component.ts
+++ b/frontend/src/app/shared/components/modals/find-or-create-site-modal/find-or-create-site-modal.component.ts
@@ -8,8 +8,8 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatDividerModule } from '@angular/material/divider';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { CheckboxComponent } from '../../checkbox/checkbox.component';
 import { catchError, debounceTime, forkJoin, of, Subject } from 'rxjs';
 
 import { AdminService } from '../../../../core/services/admin.service';
@@ -45,7 +45,7 @@ interface SearchableSite extends AdminSite {
     MatChipsModule,
     MatProgressSpinnerModule,
     MatDividerModule,
-    MatCheckboxModule,
+    CheckboxComponent,
     TranslateModule
   ],
   templateUrl: './find-or-create-site-modal.component.html',

--- a/frontend/src/app/shared/components/modals/import-list-dialog/import-list-dialog.component.html
+++ b/frontend/src/app/shared/components/modals/import-list-dialog/import-list-dialog.component.html
@@ -28,15 +28,14 @@
       </p>
     }
 
-    <mat-form-field appearance="outline" class="codes-textarea">
-      <mat-label>{{ (type === 'taxon' ? 'enjeux.importList.codesLabelTaxon' : type === 'habitat' ? 'enjeux.importList.codesLabelHabitat' : 'enjeux.importList.codesLabelGeology') | translate }}</mat-label>
-      <textarea matInput
+    <app-form-field [label]="(type === 'taxon' ? 'enjeux.importList.codesLabelTaxon' : type === 'habitat' ? 'enjeux.importList.codesLabelHabitat' : 'enjeux.importList.codesLabelGeology') | translate">
+  <textarea
                 rows="8"
                 [value]="codesInput()"
                 (input)="codesInput.set($any($event.target).value)"
                 [placeholder]="(type === 'taxon' ? 'enjeux.importList.placeholderTaxon' : type === 'habitat' ? 'enjeux.importList.placeholderHabitat' : 'enjeux.importList.placeholderGeology') | translate">
       </textarea>
-    </mat-form-field>
+</app-form-field>
 
     <div class="file-upload-section">
       <span class="file-upload-label">{{ 'enjeux.importList.orUploadFile' | translate }}</span>

--- a/frontend/src/app/shared/components/modals/import-list-dialog/import-list-dialog.component.ts
+++ b/frontend/src/app/shared/components/modals/import-list-dialog/import-list-dialog.component.ts
@@ -10,6 +10,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { TaxonomyService, BulkValidationFoundItem, BulkValidationNotFoundItem } from '../../../../core/services/taxonomy.service';
 import { HabitatService, HabitatBulkFoundItem, HabitatBulkNotFoundItem } from '../../../../core/services/habitat.service';
 import { GeologyService, InpgBulkFoundItem, InpgBulkNotFoundItem } from '../../../../core/services/geology.service';
+import { FormFieldComponent } from '../../form-field/form-field.component';
 
 export interface ImportListDialogData {
   type: 'taxon' | 'habitat' | 'geology';
@@ -50,6 +51,7 @@ export interface RejectedEntry {
     MatProgressSpinnerModule,
     MatIconModule,
     TranslateModule,
+    FormFieldComponent,
   ],
   templateUrl: './import-list-dialog.component.html',
   styleUrl: './import-list-dialog.component.scss',

--- a/frontend/src/app/shared/components/modals/invite-modal/invite-modal.component.html
+++ b/frontend/src/app/shared/components/modals/invite-modal/invite-modal.component.html
@@ -33,8 +33,9 @@
   }
 
   <!-- Autocomplete search -->
-  <mat-form-field appearance="outline" class="full-width">
-    <mat-label>{{ getPlaceholder() }}</mat-label>
+  <label class="app-mat-label">{{ getPlaceholder() }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+    <mat-label></mat-label>
     <input
       matInput
       [formControl]="searchControl"

--- a/frontend/src/app/shared/components/modals/invite-modal/invite-modal.component.html
+++ b/frontend/src/app/shared/components/modals/invite-modal/invite-modal.component.html
@@ -89,16 +89,16 @@
   }
 
   <!-- Justification (optionnel) -->
-  <mat-form-field appearance="outline" class="full-width">
-    <mat-label>{{ 'modals.invite.justification' | translate }}</mat-label>
+  <app-form-field
+    class="full-width"
+    [label]="'modals.invite.justification' | translate"
+    [helpText]="'modals.invite.justificationHint' | translate">
     <textarea
-      matInput
       [formControl]="justificationControl"
       [placeholder]="'modals.invite.justificationPlaceholder' | translate"
       rows="3">
     </textarea>
-    <mat-hint>{{ 'modals.invite.justificationHint' | translate }}</mat-hint>
-  </mat-form-field>
+  </app-form-field>
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">

--- a/frontend/src/app/shared/components/modals/invite-modal/invite-modal.component.ts
+++ b/frontend/src/app/shared/components/modals/invite-modal/invite-modal.component.ts
@@ -14,6 +14,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { debounceTime, distinctUntilChanged, switchMap, of, catchError } from 'rxjs';
 
+import { FormFieldComponent } from '../../form-field/form-field.component';
 import { AdminService } from '../../../../core/services/admin.service';
 import { ValidationService } from '../../../../core/services/validation.service';
 import { AdminOrganisme, AdminSite, AdminUser } from '../../../../core/models/admin.model';
@@ -40,7 +41,8 @@ export interface InviteModalData {
     MatProgressSpinnerModule,
     MatInputModule,
     MatIconModule,
-    TranslateModule
+    TranslateModule,
+    FormFieldComponent,
   ],
   templateUrl: './invite-modal.component.html',
   styleUrl: './invite-modal.component.scss'

--- a/frontend/src/app/shared/components/modals/link-operation-dialog/link-operation-dialog.component.html
+++ b/frontend/src/app/shared/components/modals/link-operation-dialog/link-operation-dialog.component.html
@@ -32,13 +32,12 @@
     </div>
   } @else {
     <!-- Phase 2 : Recherche et sélection d'une action existante -->
-    <mat-form-field appearance="outline" class="search-field">
-      <mat-label>{{ 'enjeux.operations.linkDialog.searchPlaceholder' | translate }}</mat-label>
-      <input matInput
+    <app-form-field [label]="'enjeux.operations.linkDialog.searchPlaceholder' | translate">
+  <input
              [ngModel]="searchTerm()"
              (ngModelChange)="onSearchChange($event)">
       <i matPrefix class="fi fi-rr-search search-icon"></i>
-    </mat-form-field>
+</app-form-field>
 
     @if (isLoading()) {
       <div class="loading-container">

--- a/frontend/src/app/shared/components/modals/link-operation-dialog/link-operation-dialog.component.ts
+++ b/frontend/src/app/shared/components/modals/link-operation-dialog/link-operation-dialog.component.ts
@@ -10,6 +10,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { EnjeuService } from '../../../../core/services/enjeu.service';
+import { FormFieldComponent } from '../../form-field/form-field.component';
 
 export interface LinkOperationDialogData {
   planId: number;
@@ -45,6 +46,7 @@ interface OperationItem {
     MatProgressSpinnerModule,
     MatTooltipModule,
     TranslateModule,
+    FormFieldComponent,
   ],
   templateUrl: './link-operation-dialog.component.html',
   styleUrl: './link-operation-dialog.component.scss',

--- a/frontend/src/app/shared/components/modals/link-plan-referent-modal/link-plan-referent-modal.component.html
+++ b/frontend/src/app/shared/components/modals/link-plan-referent-modal/link-plan-referent-modal.component.html
@@ -104,8 +104,9 @@
         </h3>
 
         <div class="add-referent-form">
-          <mat-form-field appearance="outline" class="user-search-field">
-            <mat-label>{{ 'modals.linkPlanReferent.searchUser' | translate }}</mat-label>
+          <label class="app-mat-label">{{ 'modals.linkPlanReferent.searchUser' | translate }}</label>
+      <mat-form-field class="app-mat-form-field user-search-field" appearance="outline">>
+            <mat-label></mat-label>
             <input matInput
                    [formControl]="userControl"
                    [matAutocomplete]="userAuto"

--- a/frontend/src/app/shared/components/modals/link-plan-site-modal/link-plan-site-modal.component.html
+++ b/frontend/src/app/shared/components/modals/link-plan-site-modal/link-plan-site-modal.component.html
@@ -97,8 +97,9 @@
         </h3>
 
         <div class="add-site-form">
-          <mat-form-field appearance="outline" class="site-search-field">
-            <mat-label>Rechercher un site</mat-label>
+          <label class="app-mat-label">Rechercher un site</label>
+      <mat-form-field class="app-mat-form-field site-search-field" appearance="outline">>
+            <mat-label></mat-label>
             <input matInput
                    [formControl]="siteControl"
                    [matAutocomplete]="siteAuto"

--- a/frontend/src/app/shared/components/modals/link-plan-to-site-dialog/link-plan-to-site-dialog.component.html
+++ b/frontend/src/app/shared/components/modals/link-plan-to-site-dialog/link-plan-to-site-dialog.component.html
@@ -24,8 +24,9 @@
       }
 
       <div class="search-section">
-        <mat-form-field appearance="outline" class="plan-search-field">
-          <mat-label>{{ 'modals.linkPlanToSite.search' | translate }}</mat-label>
+        <label class="app-mat-label">{{ 'modals.linkPlanToSite.search' | translate }}</label>
+      <mat-form-field class="app-mat-form-field plan-search-field" appearance="outline">>
+          <mat-label></mat-label>
           <input matInput
                  [formControl]="planControl"
                  [matAutocomplete]="planAuto"

--- a/frontend/src/app/shared/components/modals/link-site-organisme-modal/link-site-organisme-modal.component.html
+++ b/frontend/src/app/shared/components/modals/link-site-organisme-modal/link-site-organisme-modal.component.html
@@ -106,8 +106,9 @@
           </h3>
 
           <div class="add-site-form">
-            <mat-form-field appearance="outline" class="site-search-field">
-              <mat-label>Rechercher un site</mat-label>
+            <label class="app-mat-label">Rechercher un site</label>
+      <mat-form-field class="app-mat-form-field site-search-field" appearance="outline">>
+              <mat-label></mat-label>
               <input
                 type="text"
                 matInput
@@ -234,8 +235,9 @@
           </h3>
 
           <div class="add-organisme-form">
-            <mat-form-field appearance="outline" class="organisme-search-field">
-              <mat-label>Rechercher un organisme</mat-label>
+            <label class="app-mat-label">Rechercher un organisme</label>
+      <mat-form-field class="app-mat-form-field organisme-search-field" appearance="outline">>
+              <mat-label></mat-label>
               <input
                 type="text"
                 matInput

--- a/frontend/src/app/shared/components/modals/link-user-organisme-modal/link-user-organisme-modal.component.html
+++ b/frontend/src/app/shared/components/modals/link-user-organisme-modal/link-user-organisme-modal.component.html
@@ -105,8 +105,9 @@
           </h3>
 
           <div class="add-user-form">
-            <mat-form-field appearance="outline" class="user-search-field">
-              <mat-label>{{ 'modals.linkUserOrganisme.searchUser' | translate }}</mat-label>
+            <label class="app-mat-label">{{ 'modals.linkUserOrganisme.searchUser' | translate }}</label>
+      <mat-form-field class="app-mat-form-field user-search-field" appearance="outline">>
+              <mat-label></mat-label>
               <input
                 type="text"
                 matInput
@@ -171,8 +172,9 @@
           </div>
         </div>
 
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>{{ 'modals.linkUserOrganisme.organisme' | translate }}</mat-label>
+        <label class="app-mat-label">{{ 'modals.linkUserOrganisme.organisme' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+          <mat-label></mat-label>
           <mat-select [(ngModel)]="selectedOrganismeUuid">
             <mat-option [value]="null">{{ 'modals.linkUserOrganisme.noOrganisme' | translate }}</mat-option>
             @for (org of organismes(); track org.uuid_organisme) {

--- a/frontend/src/app/shared/components/modals/link-user-site-modal/link-user-site-modal.component.html
+++ b/frontend/src/app/shared/components/modals/link-user-site-modal/link-user-site-modal.component.html
@@ -116,8 +116,9 @@
           </h3>
 
           <div class="add-site-form">
-            <mat-form-field appearance="outline" class="site-search-field">
-              <mat-label>Rechercher un site</mat-label>
+            <label class="app-mat-label">Rechercher un site</label>
+      <mat-form-field class="app-mat-form-field site-search-field" appearance="outline">>
+              <mat-label></mat-label>
               <input
                 type="text"
                 matInput
@@ -258,8 +259,9 @@
           </h3>
 
           <div class="add-user-form">
-            <mat-form-field appearance="outline" class="user-search-field">
-              <mat-label>Rechercher un utilisateur</mat-label>
+            <label class="app-mat-label">Rechercher un utilisateur</label>
+      <mat-form-field class="app-mat-form-field user-search-field" appearance="outline">>
+              <mat-label></mat-label>
               <input
                 type="text"
                 matInput

--- a/frontend/src/app/shared/components/modals/manage-site-users-modal/manage-site-users-modal.component.html
+++ b/frontend/src/app/shared/components/modals/manage-site-users-modal/manage-site-users-modal.component.html
@@ -53,8 +53,9 @@
           <!-- Filtre par organisme -->
           @if (linkedOrganismes().length > 1) {
             <div class="organisme-filter">
-              <mat-form-field appearance="outline" class="filter-field">
-                <mat-label>{{ 'modals.manageSiteUsers.filterByOrganisme' | translate }}</mat-label>
+              <label class="app-mat-label">{{ 'modals.manageSiteUsers.filterByOrganisme' | translate }}</label>
+      <mat-form-field class="app-mat-form-field filter-field" appearance="outline">>
+                <mat-label></mat-label>
                 <mat-select [value]="selectedOrganismeFilter()" (selectionChange)="onOrganismeFilterChange($event.value)">
                   <mat-option [value]="null">{{ 'modals.manageSiteUsers.allOrganismes' | translate }}</mat-option>
                   @for (org of linkedOrganismes(); track org.id_organisme) {
@@ -69,8 +70,9 @@
 
           <!-- Recherche utilisateur -->
           <div class="user-search">
-            <mat-form-field appearance="outline" class="search-field">
-              <mat-label>{{ 'modals.manageSiteUsers.searchUser' | translate }}</mat-label>
+            <label class="app-mat-label">{{ 'modals.manageSiteUsers.searchUser' | translate }}</label>
+      <mat-form-field class="app-mat-form-field search-field" appearance="outline">>
+              <mat-label></mat-label>
               <input
                 matInput
                 type="text"

--- a/frontend/src/app/shared/components/modals/organisme-form-modal/organisme-form-modal.component.html
+++ b/frontend/src/app/shared/components/modals/organisme-form-modal/organisme-form-modal.component.html
@@ -36,10 +36,9 @@
     </mat-form-field>
 
     <div class="form-row">
-      <mat-form-field appearance="outline">
-        <mat-label>{{ 'modals.organismeForm.address' | translate }}</mat-label>
-        <input matInput formControlName="adresse_organisme" [placeholder]="'modals.organismeForm.addressPlaceholder' | translate">
-      </mat-form-field>
+      <app-form-field [label]="'modals.organismeForm.address' | translate">
+  <input formControlName="adresse_organisme" [placeholder]="'modals.organismeForm.addressPlaceholder' | translate">
+</app-form-field>
     </div>
 
     <div class="form-row two-columns">
@@ -53,17 +52,15 @@
   </ng-container>
 </app-form-field>
 
-      <mat-form-field appearance="outline">
-        <mat-label>{{ 'modals.organismeForm.city' | translate }}</mat-label>
-        <input matInput formControlName="ville_organisme" [placeholder]="'modals.organismeForm.cityPlaceholder' | translate">
-      </mat-form-field>
+      <app-form-field [label]="'modals.organismeForm.city' | translate">
+  <input formControlName="ville_organisme" [placeholder]="'modals.organismeForm.cityPlaceholder' | translate">
+</app-form-field>
     </div>
 
     <div class="form-row two-columns">
-      <mat-form-field appearance="outline">
-        <mat-label>{{ 'modals.organismeForm.phone' | translate }}</mat-label>
-        <input matInput formControlName="tel_organisme" [placeholder]="'modals.organismeForm.phonePlaceholder' | translate">
-      </mat-form-field>
+      <app-form-field [label]="'modals.organismeForm.phone' | translate">
+  <input formControlName="tel_organisme" [placeholder]="'modals.organismeForm.phonePlaceholder' | translate">
+</app-form-field>
 
       <app-form-field [label]="'modals.organismeForm.email' | translate">
   <input type="email" formControlName="email_organisme" [placeholder]="'modals.organismeForm.emailPlaceholder' | translate">
@@ -76,11 +73,9 @@
 </app-form-field>
     </div>
 
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>{{ 'modals.organismeForm.website' | translate }}</mat-label>
-      <input matInput formControlName="url_organisme" [placeholder]="'modals.organismeForm.websitePlaceholder' | translate">
-      <mat-hint>{{ 'modals.organismeForm.websiteHint' | translate }}</mat-hint>
-    </mat-form-field>
+    <app-form-field [label]="'modals.organismeForm.website' | translate" [helpText]="'modals.organismeForm.websiteHint' | translate">
+  <input formControlName="url_organisme" [placeholder]="'modals.organismeForm.websitePlaceholder' | translate">
+</app-form-field>
   </form>
 </mat-dialog-content>
 

--- a/frontend/src/app/shared/components/modals/organisme-form-modal/organisme-form-modal.component.html
+++ b/frontend/src/app/shared/components/modals/organisme-form-modal/organisme-form-modal.component.html
@@ -15,13 +15,15 @@
   }
 
   <form [formGroup]="form" class="organisme-form">
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>{{ 'modals.organismeForm.name' | translate }} *</mat-label>
-      <input matInput formControlName="nom_organisme" [placeholder]="'modals.organismeForm.namePlaceholder' | translate">
+    <app-form-field [label]="('modals.organismeForm.name' | translate) + ' *'" [required]="true">
+  <input formControlName="nom_organisme" [placeholder]="'modals.organismeForm.namePlaceholder' | translate">
       @if (form.get('nom_organisme')?.hasError('required') && form.get('nom_organisme')?.touched) {
-        <mat-error>{{ 'common.validation.required' | translate }}</mat-error>
+        
       }
-    </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'common.validation.required' | translate }}</p>
+  </ng-container>
+</app-form-field>
 
     <mat-form-field appearance="outline" class="full-width">
       <mat-label>{{ 'modals.organismeForm.parent' | translate }}</mat-label>
@@ -41,13 +43,15 @@
     </div>
 
     <div class="form-row two-columns">
-      <mat-form-field appearance="outline">
-        <mat-label>{{ 'modals.organismeForm.postalCode' | translate }}</mat-label>
-        <input matInput formControlName="cp_organisme" [placeholder]="'modals.organismeForm.postalCodePlaceholder' | translate">
+      <app-form-field [label]="'modals.organismeForm.postalCode' | translate">
+  <input formControlName="cp_organisme" [placeholder]="'modals.organismeForm.postalCodePlaceholder' | translate">
         @if (form.get('cp_organisme')?.hasError('pattern') && form.get('cp_organisme')?.touched) {
-          <mat-error>{{ 'modals.organismeForm.validation.postalCodeInvalid' | translate }}</mat-error>
+          
         }
-      </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'modals.organismeForm.validation.postalCodeInvalid' | translate }}</p>
+  </ng-container>
+</app-form-field>
 
       <mat-form-field appearance="outline">
         <mat-label>{{ 'modals.organismeForm.city' | translate }}</mat-label>
@@ -61,13 +65,15 @@
         <input matInput formControlName="tel_organisme" [placeholder]="'modals.organismeForm.phonePlaceholder' | translate">
       </mat-form-field>
 
-      <mat-form-field appearance="outline">
-        <mat-label>{{ 'modals.organismeForm.email' | translate }}</mat-label>
-        <input matInput type="email" formControlName="email_organisme" [placeholder]="'modals.organismeForm.emailPlaceholder' | translate">
+      <app-form-field [label]="'modals.organismeForm.email' | translate">
+  <input type="email" formControlName="email_organisme" [placeholder]="'modals.organismeForm.emailPlaceholder' | translate">
         @if (form.get('email_organisme')?.hasError('email') && form.get('email_organisme')?.touched) {
-          <mat-error>{{ 'common.validation.emailInvalid' | translate }}</mat-error>
+          
         }
-      </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'common.validation.emailInvalid' | translate }}</p>
+  </ng-container>
+</app-form-field>
     </div>
 
     <mat-form-field appearance="outline" class="full-width">

--- a/frontend/src/app/shared/components/modals/organisme-form-modal/organisme-form-modal.component.html
+++ b/frontend/src/app/shared/components/modals/organisme-form-modal/organisme-form-modal.component.html
@@ -25,8 +25,9 @@
   </ng-container>
 </app-form-field>
 
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>{{ 'modals.organismeForm.parent' | translate }}</mat-label>
+    <label class="app-mat-label">{{ 'modals.organismeForm.parent' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+      <mat-label></mat-label>
       <mat-select formControlName="parent_id">
         <mat-option [value]="null">{{ 'modals.organismeForm.noParent' | translate }}</mat-option>
         @for (org of parentOrganismes(); track org.id_organisme) {

--- a/frontend/src/app/shared/components/modals/organisme-form-modal/organisme-form-modal.component.ts
+++ b/frontend/src/app/shared/components/modals/organisme-form-modal/organisme-form-modal.component.ts
@@ -10,6 +10,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { AdminService } from '../../../../core/services/admin.service';
 import { AdminOrganisme, OrganismeCreatePayload } from '../../../../core/models/admin.model';
+import { FormFieldComponent } from '../../form-field/form-field.component';
 
 export interface OrganismeFormModalData {
   organisme?: AdminOrganisme; // If provided, edit mode
@@ -28,7 +29,8 @@ export interface OrganismeFormModalData {
     MatButtonModule,
     MatSelectModule,
     MatProgressSpinnerModule,
-    TranslateModule
+    TranslateModule,
+    FormFieldComponent,
   ],
   templateUrl: './organisme-form-modal.component.html',
   styleUrl: './organisme-form-modal.component.scss'

--- a/frontend/src/app/shared/components/modals/plan-form-modal/plan-form-modal.component.html
+++ b/frontend/src/app/shared/components/modals/plan-form-modal/plan-form-modal.component.html
@@ -204,7 +204,7 @@
             </div>
           } @else {
             <!-- Input avec autocomplete -->
-            <mat-form-field appearance="outline" class="full-width">
+            <mat-form-field appearance="outline" class="full-width app-mat-form-field">
               <input
                 matInput
                 #organismeInput

--- a/frontend/src/app/shared/components/modals/plan-form-modal/plan-form-modal.component.html
+++ b/frontend/src/app/shared/components/modals/plan-form-modal/plan-form-modal.component.html
@@ -68,11 +68,11 @@
                 (click)="toggleSite(site.id)"
               >
                 <div class="item-info">
-                  <mat-checkbox
+                  <app-checkbox
                     [checked]="isSiteSelected(site.id)"
                     (click)="$event.stopPropagation()"
-                    (change)="toggleSite(site.id)"
-                  ></mat-checkbox>
+                    (checkedChange)="toggleSite(site.id)">
+                  </app-checkbox>
                   <span class="item-name">{{ site.nom }}</span>
                   @if (site.type) {
                     <span class="item-type">{{ site.type }}</span>

--- a/frontend/src/app/shared/components/modals/plan-form-modal/plan-form-modal.component.html
+++ b/frontend/src/app/shared/components/modals/plan-form-modal/plan-form-modal.component.html
@@ -121,12 +121,10 @@
   </ng-container>
 </app-form-field>
 
-          <mat-form-field appearance="outline">
-            <mat-label>{{ 'modals.planForm.fields.surface' | translate }}</mat-label>
-            <input matInput type="number" formControlName="surface" step="0.01">
+          <app-form-field [label]="'modals.planForm.fields.surface' | translate" [helpText]="'modals.planForm.hints.surface' | translate">
+  <input type="number" formControlName="surface" step="0.01">
             <span matTextSuffix>ha</span>
-            <mat-hint>{{ 'modals.planForm.hints.surface' | translate }}</mat-hint>
-          </mat-form-field>
+</app-form-field>
         </div>
 
         <!-- CT88 (Radio buttons) -->
@@ -171,11 +169,9 @@
 
         <!-- ID Doc'Gestion FCEN (visible uniquement pour les organismes CEN) -->
         @if (hasCenOrganisme()) {
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'modals.planForm.fields.docGestion' | translate }}</mat-label>
-            <input matInput formControlName="id_docgestion_fcen">
-            <mat-hint>{{ 'modals.planForm.hints.docGestion' | translate }}</mat-hint>
-          </mat-form-field>
+          <app-form-field [label]="'modals.planForm.fields.docGestion' | translate" [helpText]="'modals.planForm.hints.docGestion' | translate">
+  <input formControlName="id_docgestion_fcen">
+</app-form-field>
         }
 
         <!-- Type organisme rédacteur -->
@@ -237,39 +233,31 @@
         </div>
 
         <!-- Rédacteurs -->
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>{{ 'modals.planForm.fields.redacteurs' | translate }}</mat-label>
-          <textarea
-            matInput
+        <app-form-field [label]="'modals.planForm.fields.redacteurs' | translate" [helpText]="'modals.planForm.hints.redacteurs' | translate">
+  <textarea
             formControlName="redacteurs"
             rows="2"
             [placeholder]="'modals.planForm.placeholders.redacteurs' | translate"
           ></textarea>
-          <mat-hint>{{ 'modals.planForm.hints.redacteurs' | translate }}</mat-hint>
-        </mat-form-field>
+</app-form-field>
 
         <!-- Relecteurs -->
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>{{ 'modals.planForm.fields.relecteurs' | translate }}</mat-label>
-          <textarea
-            matInput
+        <app-form-field [label]="'modals.planForm.fields.relecteurs' | translate" [helpText]="'modals.planForm.hints.relecteurs' | translate">
+  <textarea
             formControlName="relecteurs"
             rows="2"
             [placeholder]="'modals.planForm.placeholders.relecteurs' | translate"
           ></textarea>
-          <mat-hint>{{ 'modals.planForm.hints.relecteurs' | translate }}</mat-hint>
-        </mat-form-field>
+</app-form-field>
 
         <!-- Autres rédacteurs -->
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>{{ 'modals.planForm.fields.autresContributeurs' | translate }}</mat-label>
-          <textarea
-            matInput
+        <app-form-field [label]="'modals.planForm.fields.autresContributeurs' | translate">
+  <textarea
             formControlName="autres_contributeurs"
             rows="2"
             [placeholder]="'modals.planForm.placeholders.autresContributeurs' | translate"
           ></textarea>
-        </mat-form-field>
+</app-form-field>
 
       </form>
     }

--- a/frontend/src/app/shared/components/modals/plan-form-modal/plan-form-modal.component.html
+++ b/frontend/src/app/shared/components/modals/plan-form-modal/plan-form-modal.component.html
@@ -160,8 +160,9 @@
         </div>
 
         <!-- Date validation CSPN -->
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>{{ 'modals.planForm.fields.cspnDate' | translate }}</mat-label>
+        <label class="app-mat-label">{{ 'modals.planForm.fields.cspnDate' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+          <mat-label></mat-label>
           <input matInput [matDatepicker]="cspnPicker" formControlName="date_avis_csrpn">
           <mat-datepicker-toggle matIconSuffix [for]="cspnPicker"></mat-datepicker-toggle>
           <mat-datepicker #cspnPicker></mat-datepicker>
@@ -175,8 +176,9 @@
         }
 
         <!-- Type organisme rédacteur -->
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>{{ 'modals.planForm.fields.editorType' | translate }}</mat-label>
+        <label class="app-mat-label">{{ 'modals.planForm.fields.editorType' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+          <mat-label></mat-label>
           <mat-select formControlName="id_redacteur_type">
             <mat-option [value]="null">{{ 'common.none' | translate }}</mat-option>
             @for (type of redacteurTypes(); track type.id_nomenclature) {

--- a/frontend/src/app/shared/components/modals/plan-form-modal/plan-form-modal.component.html
+++ b/frontend/src/app/shared/components/modals/plan-form-modal/plan-form-modal.component.html
@@ -21,13 +21,15 @@
         }
 
         <!-- Nom du plan * -->
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>{{ 'modals.planForm.fields.name' | translate }} *</mat-label>
-          <input matInput formControlName="nom" [placeholder]="'modals.planForm.placeholders.name' | translate">
+        <app-form-field [label]="('modals.planForm.fields.name' | translate) + ' *'" [required]="true">
+  <input formControlName="nom" [placeholder]="'modals.planForm.placeholders.name' | translate">
           @if (form.get('nom')?.hasError('required')) {
-            <mat-error>{{ 'modals.planForm.validation.nameRequired' | translate }}</mat-error>
+            
           }
-        </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'modals.planForm.validation.nameRequired' | translate }}</p>
+  </ng-container>
+</app-form-field>
 
         <!-- Choix des sites * -->
         <div class="form-section sites-section">
@@ -104,17 +106,20 @@
 
         <!-- Rang et Surface -->
         <div class="form-row">
-          <mat-form-field appearance="outline">
-            <mat-label>{{ 'modals.planForm.fields.rang' | translate }} *</mat-label>
-            <input matInput type="number" formControlName="rang" min="1">
-            <mat-hint>{{ 'modals.planForm.hints.rang' | translate }}</mat-hint>
+          <app-form-field [label]="('modals.planForm.fields.rang' | translate) + ' *'" [required]="true" [helpText]="'modals.planForm.hints.rang' | translate">
+  <input type="number" formControlName="rang" min="1">
+            
             @if (form.get('rang')?.hasError('required')) {
-              <mat-error>{{ 'modals.planForm.validation.rangRequired' | translate }}</mat-error>
+              
             }
             @if (form.get('rang')?.hasError('min')) {
-              <mat-error>{{ 'modals.planForm.validation.rangMin' | translate }}</mat-error>
+              
             }
-          </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'modals.planForm.validation.rangRequired' | translate }}</p>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'modals.planForm.validation.rangMin' | translate }}</p>
+  </ng-container>
+</app-form-field>
 
           <mat-form-field appearance="outline">
             <mat-label>{{ 'modals.planForm.fields.surface' | translate }}</mat-label>
@@ -135,21 +140,25 @@
 
         <!-- Année début et Année fin -->
         <div class="form-row">
-          <mat-form-field appearance="outline">
-            <mat-label>{{ 'modals.planForm.fields.startYear' | translate }} *</mat-label>
-            <input matInput type="number" formControlName="annee_debut" min="1900" max="2100">
+          <app-form-field [label]="('modals.planForm.fields.startYear' | translate) + ' *'" [required]="true">
+  <input type="number" formControlName="annee_debut" min="1900" max="2100">
             @if (form.get('annee_debut')?.hasError('required')) {
-              <mat-error>{{ 'common.validation.required' | translate }}</mat-error>
+              
             }
-          </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'common.validation.required' | translate }}</p>
+  </ng-container>
+</app-form-field>
 
-          <mat-form-field appearance="outline">
-            <mat-label>{{ 'modals.planForm.fields.endYear' | translate }} *</mat-label>
-            <input matInput type="number" formControlName="annee_fin" min="1900" max="2100">
+          <app-form-field [label]="('modals.planForm.fields.endYear' | translate) + ' *'" [required]="true">
+  <input type="number" formControlName="annee_fin" min="1900" max="2100">
             @if (form.get('annee_fin')?.hasError('required')) {
-              <mat-error>{{ 'common.validation.required' | translate }}</mat-error>
+              
             }
-          </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'common.validation.required' | translate }}</p>
+  </ng-container>
+</app-form-field>
         </div>
 
         <!-- Date validation CSPN -->

--- a/frontend/src/app/shared/components/modals/plan-form-modal/plan-form-modal.component.ts
+++ b/frontend/src/app/shared/components/modals/plan-form-modal/plan-form-modal.component.ts
@@ -6,7 +6,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSelectModule } from '@angular/material/select';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
@@ -23,6 +22,7 @@ import { AdminService } from '../../../../core/services/admin.service';
 import { OrganismeFormModalComponent } from '../organisme-form-modal/organisme-form-modal.component';
 import { AuthService } from '../../../../core/services/auth.service';
 import { ViewScopeToggleComponent, ViewScope } from '../../view-scope-toggle/view-scope-toggle.component';
+import { CheckboxComponent } from '../../checkbox/checkbox.component';
 import {
   AdminPlan,
   PlanCreatePayload,
@@ -78,7 +78,7 @@ interface OrganismeEntry {
     MatInputModule,
     MatButtonModule,
     MatSelectModule,
-    MatCheckboxModule,
+    CheckboxComponent,
     MatProgressSpinnerModule,
     MatChipsModule,
     MatIconModule,

--- a/frontend/src/app/shared/components/modals/plan-form-modal/plan-form-modal.component.ts
+++ b/frontend/src/app/shared/components/modals/plan-form-modal/plan-form-modal.component.ts
@@ -23,6 +23,7 @@ import { OrganismeFormModalComponent } from '../organisme-form-modal/organisme-f
 import { AuthService } from '../../../../core/services/auth.service';
 import { ViewScopeToggleComponent, ViewScope } from '../../view-scope-toggle/view-scope-toggle.component';
 import { CheckboxComponent } from '../../checkbox/checkbox.component';
+import { FormFieldComponent } from '../../form-field/form-field.component';
 import {
   AdminPlan,
   PlanCreatePayload,
@@ -90,7 +91,8 @@ interface OrganismeEntry {
     MatSnackBarModule,
     TranslateModule,
     RouterModule,
-    ViewScopeToggleComponent
+    ViewScopeToggleComponent,
+    FormFieldComponent,
   ],
   templateUrl: './plan-form-modal.component.html',
   styleUrl: './plan-form-modal.component.scss'

--- a/frontend/src/app/shared/components/modals/remove-user-organisme-modal/remove-user-organisme-modal.component.html
+++ b/frontend/src/app/shared/components/modals/remove-user-organisme-modal/remove-user-organisme-modal.component.html
@@ -24,16 +24,17 @@
 
     <!-- Reason field -->
     <div class="reason-section">
-      <label class="reason-label">Raison du retrait *</label>
-      <mat-form-field appearance="outline" class="full-width">
+      <app-form-field
+        class="full-width"
+        label="Raison du retrait"
+        [required]="true"
+        [helpText]="reason.length + ' / 10 caracteres minimum'">
         <textarea
-          matInput
           [(ngModel)]="reason"
           placeholder="Indiquez la raison du retrait (minimum 10 caracteres)..."
           rows="3"
         ></textarea>
-        <mat-hint>{{ reason.length }} / 10 caracteres minimum</mat-hint>
-      </mat-form-field>
+      </app-form-field>
 
       @if (errorMessage()) {
         <div class="error-message">

--- a/frontend/src/app/shared/components/modals/remove-user-organisme-modal/remove-user-organisme-modal.component.ts
+++ b/frontend/src/app/shared/components/modals/remove-user-organisme-modal/remove-user-organisme-modal.component.ts
@@ -2,10 +2,9 @@ import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { FormFieldComponent } from '../../form-field/form-field.component';
 
 export interface RemoveUserOrganismeModalData {
   userName: string;
@@ -25,10 +24,9 @@ export interface RemoveUserOrganismeModalResult {
     CommonModule,
     FormsModule,
     MatDialogModule,
-    MatFormFieldModule,
-    MatInputModule,
     MatButtonModule,
-    TranslateModule
+    TranslateModule,
+    FormFieldComponent,
   ],
   templateUrl: './remove-user-organisme-modal.component.html',
   styleUrl: './remove-user-organisme-modal.component.scss'

--- a/frontend/src/app/shared/components/modals/site-form-modal/site-form-modal.component.html
+++ b/frontend/src/app/shared/components/modals/site-form-modal/site-form-modal.component.html
@@ -190,13 +190,15 @@
       }
 
       <form [formGroup]="form" class="site-form">
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>{{ 'modals.siteForm.fields.name' | translate }} *</mat-label>
-          <input matInput formControlName="nom_site" placeholder="Ex: Reserve Naturelle de la Camargue" (input)="onNameInput($event)">
+        <app-form-field [label]="('modals.siteForm.fields.name' | translate) + ' *'" [required]="true">
+  <input formControlName="nom_site" placeholder="Ex: Reserve Naturelle de la Camargue" (input)="onNameInput($event)">
           @if (form.get('nom_site')?.hasError('required') && form.get('nom_site')?.touched) {
-            <mat-error>{{ 'modals.siteForm.errors.nameRequired' | translate }}</mat-error>
+            
           }
-        </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'modals.siteForm.errors.nameRequired' | translate }}</p>
+  </ng-container>
+</app-form-field>
 
         <div class="form-row two-columns">
           <app-form-field [label]="'modals.siteForm.fields.localId' | translate" [helpText]="'modals.siteForm.hints.localId' | translate">
@@ -225,13 +227,15 @@
             </mat-select>
           </mat-form-field>
 
-          <mat-form-field appearance="outline">
-            <mat-label>{{ 'modals.siteForm.fields.surface' | translate }}</mat-label>
-            <input matInput type="number" formControlName="surf_off" placeholder="Ex: 1500">
+          <app-form-field [label]="'modals.siteForm.fields.surface' | translate">
+  <input type="number" formControlName="surf_off" placeholder="Ex: 1500">
             @if (form.get('surf_off')?.hasError('min')) {
-              <mat-error>{{ 'modals.siteForm.errors.surfacePositive' | translate }}</mat-error>
+              
             }
-          </mat-form-field>
+  <ng-container errorSlot>
+    <p class="form-error-msg"><i class="fi fi-rr-exclamation"></i> {{ 'modals.siteForm.errors.surfacePositive' | translate }}</p>
+  </ng-container>
+</app-form-field>
         </div>
 
         <!-- Precision field (only shown when type is "Autre") -->

--- a/frontend/src/app/shared/components/modals/site-form-modal/site-form-modal.component.html
+++ b/frontend/src/app/shared/components/modals/site-form-modal/site-form-modal.component.html
@@ -211,8 +211,9 @@
         </div>
 
         <div class="form-row two-columns">
-          <mat-form-field appearance="outline">
-            <mat-label>{{ 'modals.siteForm.fields.type' | translate }}</mat-label>
+          <label class="app-mat-label">{{ 'modals.siteForm.fields.type' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+            <mat-label></mat-label>
             <mat-select formControlName="id_type_site">
               <mat-option [value]="null">-- {{ 'common.actions.select' | translate }} --</mat-option>
               @if (isLoadingTypes()) {

--- a/frontend/src/app/shared/components/modals/site-form-modal/site-form-modal.component.html
+++ b/frontend/src/app/shared/components/modals/site-form-modal/site-form-modal.component.html
@@ -199,17 +199,13 @@
         </mat-form-field>
 
         <div class="form-row two-columns">
-          <mat-form-field appearance="outline">
-            <mat-label>{{ 'modals.siteForm.fields.localId' | translate }}</mat-label>
-            <input matInput formControlName="id_local" placeholder="Ex: RN13">
-            <mat-hint>{{ 'modals.siteForm.hints.localId' | translate }}</mat-hint>
-          </mat-form-field>
+          <app-form-field [label]="'modals.siteForm.fields.localId' | translate" [helpText]="'modals.siteForm.hints.localId' | translate">
+  <input formControlName="id_local" placeholder="Ex: RN13">
+</app-form-field>
 
-          <mat-form-field appearance="outline">
-            <mat-label>{{ 'modals.siteForm.fields.inpnId' | translate }}</mat-label>
-            <input matInput formControlName="id_inpn" placeholder="Ex: FR3600013" (input)="onInpnInput($event)">
-            <mat-hint>{{ 'modals.siteForm.hints.inpnId' | translate }}</mat-hint>
-          </mat-form-field>
+          <app-form-field [label]="'modals.siteForm.fields.inpnId' | translate" [helpText]="'modals.siteForm.hints.inpnId' | translate">
+  <input formControlName="id_inpn" placeholder="Ex: FR3600013" (input)="onInpnInput($event)">
+</app-form-field>
         </div>
 
         <div class="form-row two-columns">
@@ -240,11 +236,9 @@
 
         <!-- Precision field (only shown when type is "Autre") -->
         @if (isTypeAutre) {
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>{{ 'modals.siteForm.fields.typePrecision' | translate }} *</mat-label>
-            <input matInput formControlName="type_site_precision" [placeholder]="'modals.siteForm.hints.typePrecision' | translate">
-            <mat-hint>{{ 'modals.siteForm.hints.typePrecision' | translate }}</mat-hint>
-          </mat-form-field>
+          <app-form-field [label]="('modals.siteForm.fields.typePrecision' | translate) + ' *'" [helpText]="'modals.siteForm.hints.typePrecision' | translate">
+  <input formControlName="type_site_precision" [placeholder]="'modals.siteForm.hints.typePrecision' | translate">
+</app-form-field>
         }
 
         <div class="checkbox-row">

--- a/frontend/src/app/shared/components/modals/site-form-modal/site-form-modal.component.html
+++ b/frontend/src/app/shared/components/modals/site-form-modal/site-form-modal.component.html
@@ -248,18 +248,19 @@
         }
 
         <div class="checkbox-row">
-          <mat-checkbox formControlName="marin">{{ 'modals.siteForm.fields.marine' | translate }}</mat-checkbox>
-          <mat-checkbox formControlName="outre_mer">{{ 'modals.siteForm.fields.overseas' | translate }}</mat-checkbox>
-          <mat-checkbox formControlName="active">{{ 'modals.siteForm.fields.active' | translate }}</mat-checkbox>
+          <app-checkbox formControlName="marin" [label]="'modals.siteForm.fields.marine' | translate"></app-checkbox>
+          <app-checkbox formControlName="outre_mer" [label]="'modals.siteForm.fields.overseas' | translate"></app-checkbox>
+          <app-checkbox formControlName="active" [label]="'modals.siteForm.fields.active' | translate"></app-checkbox>
         </div>
 
         <!-- Checkbox for referent request (only in create mode) -->
         @if (!isEditMode) {
           <div class="referent-request-section">
-            <mat-checkbox formControlName="requestAsReferent">
-              {{ 'modals.siteForm.fields.requestAsReferent' | translate }}
-            </mat-checkbox>
-            <p class="help-text">{{ 'modals.siteForm.hints.requestAsReferent' | translate }}</p>
+            <app-checkbox
+              formControlName="requestAsReferent"
+              [label]="'modals.siteForm.fields.requestAsReferent' | translate"
+              [mention]="'modals.siteForm.hints.requestAsReferent' | translate">
+            </app-checkbox>
           </div>
         }
       </form>

--- a/frontend/src/app/shared/components/modals/site-form-modal/site-form-modal.component.ts
+++ b/frontend/src/app/shared/components/modals/site-form-modal/site-form-modal.component.ts
@@ -18,6 +18,7 @@ import { AdminSite, SiteCreatePayload, GeoJSONGeometry, DuplicateCheckResult, Du
 import { LeafletMapEditComponent } from '../../leaflet-map-edit/leaflet-map-edit.component';
 import { SiteTypeDisplayPipe } from '../../../pipes/site-type-display.pipe';
 import { CheckboxComponent } from '../../checkbox/checkbox.component';
+import { FormFieldComponent } from '../../form-field/form-field.component';
 
 export interface SiteFormModalData {
   site?: AdminSite; // If provided, edit mode
@@ -61,6 +62,7 @@ interface SiteType {
     MatButtonModule,
     MatSelectModule,
     CheckboxComponent,
+    FormFieldComponent,
     MatProgressSpinnerModule,
     MatTabsModule,
     MatIconModule,

--- a/frontend/src/app/shared/components/modals/site-form-modal/site-form-modal.component.ts
+++ b/frontend/src/app/shared/components/modals/site-form-modal/site-form-modal.component.ts
@@ -6,7 +6,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSelectModule } from '@angular/material/select';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatIconModule } from '@angular/material/icon';
@@ -18,6 +17,7 @@ import { ValidationRequestListItem } from '../../../../core/models/notification.
 import { AdminSite, SiteCreatePayload, GeoJSONGeometry, DuplicateCheckResult, DuplicateSite } from '../../../../core/models/admin.model';
 import { LeafletMapEditComponent } from '../../leaflet-map-edit/leaflet-map-edit.component';
 import { SiteTypeDisplayPipe } from '../../../pipes/site-type-display.pipe';
+import { CheckboxComponent } from '../../checkbox/checkbox.component';
 
 export interface SiteFormModalData {
   site?: AdminSite; // If provided, edit mode
@@ -60,7 +60,7 @@ interface SiteType {
     MatInputModule,
     MatButtonModule,
     MatSelectModule,
-    MatCheckboxModule,
+    CheckboxComponent,
     MatProgressSpinnerModule,
     MatTabsModule,
     MatIconModule,

--- a/frontend/src/app/shared/components/modals/start-mi-parcours-dialog/start-mi-parcours-dialog.component.html
+++ b/frontend/src/app/shared/components/modals/start-mi-parcours-dialog/start-mi-parcours-dialog.component.html
@@ -35,8 +35,9 @@
           {{ 'plans.lifecycle.startMiParcours.linkEmpty' | translate }}
         </p>
       } @else {
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>{{ 'plans.lifecycle.startMiParcours.form.selectDraft' | translate }}</mat-label>
+        <label class="app-mat-label">{{ 'plans.lifecycle.startMiParcours.form.selectDraft' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+          <mat-label></mat-label>
           <mat-select [(ngModel)]="selectedDraftId">
             @for (draft of availableDrafts; track draft.id_pg) {
               <mat-option [value]="draft.id_pg">{{ draft.nom }}</mat-option>

--- a/frontend/src/app/shared/components/modals/start-revision-dialog/start-revision-dialog.component.html
+++ b/frontend/src/app/shared/components/modals/start-revision-dialog/start-revision-dialog.component.html
@@ -30,21 +30,22 @@
   <!-- Formulaire création -->
   @if (mode === 'create') {
     <div class="form-block">
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>{{ 'plans.lifecycle.startRevision.form.name' | translate }}</mat-label>
-        <input matInput [(ngModel)]="nom" required>
-      </mat-form-field>
+      <app-form-field class="full-width"
+                      [label]="'plans.lifecycle.startRevision.form.name' | translate"
+                      [required]="true">
+        <input [(ngModel)]="nom" required>
+      </app-form-field>
 
       <div class="year-grid">
-        <mat-form-field appearance="outline">
-          <mat-label>{{ 'plans.lifecycle.startRevision.form.yearStart' | translate }}</mat-label>
-          <input matInput type="number" [(ngModel)]="anneeDebut" required>
-        </mat-form-field>
+        <app-form-field [label]="'plans.lifecycle.startRevision.form.yearStart' | translate"
+                        [required]="true">
+          <input type="number" [(ngModel)]="anneeDebut" required>
+        </app-form-field>
 
-        <mat-form-field appearance="outline">
-          <mat-label>{{ 'plans.lifecycle.startRevision.form.yearEnd' | translate }}</mat-label>
-          <input matInput type="number" [(ngModel)]="anneeFin" required>
-        </mat-form-field>
+        <app-form-field [label]="'plans.lifecycle.startRevision.form.yearEnd' | translate"
+                        [required]="true">
+          <input type="number" [(ngModel)]="anneeFin" required>
+        </app-form-field>
       </div>
     </div>
   }

--- a/frontend/src/app/shared/components/modals/start-revision-dialog/start-revision-dialog.component.html
+++ b/frontend/src/app/shared/components/modals/start-revision-dialog/start-revision-dialog.component.html
@@ -63,8 +63,9 @@
           {{ 'plans.lifecycle.startRevision.linkEmpty' | translate }}
         </p>
       } @else {
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>{{ 'plans.lifecycle.startRevision.form.selectDraft' | translate }}</mat-label>
+        <label class="app-mat-label">{{ 'plans.lifecycle.startRevision.form.selectDraft' | translate }}</label>
+      <mat-form-field class="app-mat-form-field full-width" appearance="outline">>
+          <mat-label></mat-label>
           <mat-select [(ngModel)]="selectedDraftId">
             @for (draft of availableDrafts; track draft.id_pg) {
               <mat-option [value]="draft.id_pg">{{ draft.nom }}</mat-option>

--- a/frontend/src/app/shared/components/modals/start-revision-dialog/start-revision-dialog.component.ts
+++ b/frontend/src/app/shared/components/modals/start-revision-dialog/start-revision-dialog.component.ts
@@ -12,6 +12,7 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { AdminService } from '../../../../core/services/admin.service';
 import { AdminPlan } from '../../../../core/models/admin.model';
+import { FormFieldComponent } from '../../form-field/form-field.component';
 
 export interface StartRevisionDialogData {
   /** Plan source qui va être marqué en révision. */
@@ -48,6 +49,7 @@ type ChoiceMode = 'create' | 'link' | 'none';
     MatRadioModule,
     MatProgressSpinnerModule,
     TranslateModule,
+    FormFieldComponent,
   ],
   templateUrl: './start-revision-dialog.component.html',
   styleUrl: './start-revision-dialog.component.scss',

--- a/frontend/src/app/shared/components/modals/upload-document-modal/upload-document-modal.component.html
+++ b/frontend/src/app/shared/components/modals/upload-document-modal/upload-document-modal.component.html
@@ -27,8 +27,9 @@
 
   <!-- Metadata fields -->
   <div class="metadata-fields">
-    <mat-form-field appearance="outline">
-      <mat-label>{{ 'plans.detail.documents.upload.type' | translate }}</mat-label>
+    <label class="app-mat-label">{{ 'plans.detail.documents.upload.type' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+      <mat-label></mat-label>
       <mat-select [(ngModel)]="typeFichier">
         @for (type of fichierTypes; track type.value) {
           <mat-option [value]="type.value">{{ type.labelKey | translate }}</mat-option>
@@ -49,8 +50,9 @@
   <input [(ngModel)]="auteur">
 </app-form-field>
 
-      <mat-form-field appearance="outline">
-        <mat-label>{{ 'plans.detail.documents.upload.dateDocument' | translate }}</mat-label>
+      <label class="app-mat-label">{{ 'plans.detail.documents.upload.dateDocument' | translate }}</label>
+      <mat-form-field class="app-mat-form-field" appearance="outline">
+        <mat-label></mat-label>
         <input matInput [matDatepicker]="picker" [(ngModel)]="dateDocument">
         <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
         <mat-datepicker #picker></mat-datepicker>

--- a/frontend/src/app/shared/components/modals/upload-document-modal/upload-document-modal.component.html
+++ b/frontend/src/app/shared/components/modals/upload-document-modal/upload-document-modal.component.html
@@ -36,21 +36,18 @@
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field appearance="outline">
-      <mat-label>{{ 'plans.detail.documents.upload.titre' | translate }}</mat-label>
-      <input matInput [(ngModel)]="titre">
-    </mat-form-field>
+    <app-form-field [label]="'plans.detail.documents.upload.titre' | translate">
+  <input [(ngModel)]="titre">
+</app-form-field>
 
-    <mat-form-field appearance="outline">
-      <mat-label>{{ 'plans.detail.documents.upload.description' | translate }}</mat-label>
-      <textarea matInput [(ngModel)]="description" rows="3"></textarea>
-    </mat-form-field>
+    <app-form-field [label]="'plans.detail.documents.upload.description' | translate">
+  <textarea [(ngModel)]="description" rows="3"></textarea>
+</app-form-field>
 
     <div class="fields-row">
-      <mat-form-field appearance="outline">
-        <mat-label>{{ 'plans.detail.documents.upload.auteur' | translate }}</mat-label>
-        <input matInput [(ngModel)]="auteur">
-      </mat-form-field>
+      <app-form-field [label]="'plans.detail.documents.upload.auteur' | translate">
+  <input [(ngModel)]="auteur">
+</app-form-field>
 
       <mat-form-field appearance="outline">
         <mat-label>{{ 'plans.detail.documents.upload.dateDocument' | translate }}</mat-label>

--- a/frontend/src/app/shared/components/modals/upload-document-modal/upload-document-modal.component.ts
+++ b/frontend/src/app/shared/components/modals/upload-document-modal/upload-document-modal.component.ts
@@ -12,6 +12,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { AdminService } from '../../../../core/services/admin.service';
 import { FichierType } from '../../../../core/models/admin.model';
+import { FormFieldComponent } from '../../form-field/form-field.component';
 
 export interface UploadDocumentDialogData {
   planId: number;
@@ -32,6 +33,7 @@ export interface UploadDocumentDialogData {
     MatNativeDateModule,
     MatProgressSpinnerModule,
     TranslateModule,
+    FormFieldComponent,
   ],
   templateUrl: './upload-document-modal.component.html',
   styleUrl: './upload-document-modal.component.scss',

--- a/frontend/src/app/shared/components/reference-item-list/reference-item-list.component.html
+++ b/frontend/src/app/shared/components/reference-item-list/reference-item-list.component.html
@@ -30,8 +30,9 @@
   }
 
   <!-- Autocomplete search -->
-  <mat-form-field appearance="outline" class="search-field">
-    <mat-label>{{ (type === 'taxon' ? 'enjeux.referenceList.searchTaxon' : type === 'habitat' ? 'enjeux.referenceList.searchHabitat' : 'enjeux.referenceList.searchGeology') | translate }}</mat-label>
+  <label class="app-mat-label">{{ (type === 'taxon' ? 'enjeux.referenceList.searchTaxon' : type === 'habitat' ? 'enjeux.referenceList.searchHabitat' : 'enjeux.referenceList.searchGeology') | translate }}</label>
+      <mat-form-field class="app-mat-form-field search-field" appearance="outline">>
+    <mat-label></mat-label>
     <input matInput
            [formControl]="searchControl"
            [matAutocomplete]="auto"

--- a/frontend/src/app/shared/components/search-bar/search-bar.component.html
+++ b/frontend/src/app/shared/components/search-bar/search-bar.component.html
@@ -1,0 +1,43 @@
+<div class="search-bar" [class.search-bar--focus]="hasFocus()" [class.search-bar--disabled]="disabled">
+  @if (helpText) {
+    <p class="search-bar__help">{{ helpText }}</p>
+  }
+
+  <div class="search-bar__field">
+    <i class="fi fi-rr-search search-bar__icon" aria-hidden="true"></i>
+
+    <input
+      #input
+      type="text"
+      class="search-bar__input"
+      [value]="value"
+      [placeholder]="placeholder"
+      [disabled]="disabled"
+      [attr.aria-label]="ariaLabel"
+      (input)="onInput($any($event.target).value)"
+      (keydown.enter)="onEnter()"
+      (focus)="onFocus()"
+      (blur)="onBlur()"
+    />
+
+    @if (value && !disabled) {
+      <button
+        type="button"
+        class="search-bar__clear"
+        [attr.aria-label]="'common.actions.clear' | translate"
+        (click)="clear()">
+        <i class="fi fi-rr-cross-small" aria-hidden="true"></i>
+      </button>
+    }
+
+    @if (mode === 'manual') {
+      <button
+        type="button"
+        class="search-bar__submit"
+        [disabled]="disabled || !value.trim()"
+        (click)="onSearchClick()">
+        {{ 'common.actions.search' | translate }}
+      </button>
+    }
+  </div>
+</div>

--- a/frontend/src/app/shared/components/search-bar/search-bar.component.scss
+++ b/frontend/src/app/shared/components/search-bar/search-bar.component.scss
@@ -1,0 +1,129 @@
+@import 'variables';
+
+// SearchBar - composant unifié (issue #298)
+
+.search-bar {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-xxs;
+  width: 100%;
+
+  // Texte d'aide AVANT le champ (accessibilité)
+  &__help {
+    margin: 0;
+    font-family: $font-family;
+    font-size: $font-size-small;
+    color: $gray-dark;
+    line-height: 1.4;
+  }
+
+  // Conteneur du champ + icône + bouton
+  &__field {
+    display: flex;
+    align-items: center;
+    gap: $spacing-xs;
+    padding: 0 $spacing-sm;
+    background-color: $white;
+    border: 1px solid $gray-light;
+    border-radius: $border-radius-pill;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    min-height: 38px;
+  }
+
+  // Icône loupe
+  &__icon {
+    color: $gray-dark;
+    font-size: 14px;
+    flex-shrink: 0;
+  }
+
+  // Champ input lui-même
+  &__input {
+    flex: 1;
+    min-width: 0;
+    height: 36px;
+    padding: 0 $spacing-xs;
+    border: none;
+    outline: none;
+    background: transparent;
+    font-family: $font-family;
+    font-size: $font-size-base;
+    color: $black;
+
+    &::placeholder {
+      color: $gray-dark;
+      opacity: 0.7;
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      color: $gray-dark;
+    }
+  }
+
+  // Bouton clear (croix)
+  &__clear {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    background: $gray-light;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    color: $gray-dark;
+    flex-shrink: 0;
+    transition: background-color 0.15s ease;
+
+    i {
+      font-size: 12px;
+      line-height: 1;
+    }
+
+    &:hover {
+      background: $gray;
+      color: $black;
+    }
+  }
+
+  // Bouton "Rechercher" (mode manual)
+  &__submit {
+    display: inline-flex;
+    align-items: center;
+    padding: $spacing-xxs $spacing-md;
+    background: $primary-color;
+    color: $white;
+    border: none;
+    border-radius: $border-radius-pill;
+    font-family: $font-family;
+    font-size: $font-size-small;
+    font-weight: $font-weight-semibold;
+    cursor: pointer;
+    transition: background-color 0.15s ease, opacity 0.15s ease;
+    flex-shrink: 0;
+    height: 28px;
+
+    &:hover:not(:disabled) {
+      background: darken($primary-color, 8%);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  // États
+  &--focus &__field {
+    border-color: $primary-color;
+    box-shadow: 0 0 0 2px rgba($primary-color, 0.12);
+  }
+
+  &--disabled &__field {
+    background: $beige;
+    border-color: $gray-light;
+    opacity: 0.7;
+  }
+}

--- a/frontend/src/app/shared/components/search-bar/search-bar.component.ts
+++ b/frontend/src/app/shared/components/search-bar/search-bar.component.ts
@@ -1,0 +1,101 @@
+import { Component, EventEmitter, Input, Output, ViewChild, ElementRef, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+
+export type SearchBarMode = 'auto' | 'manual';
+
+/**
+ * SearchBar - Composant de recherche unifié (issue #298)
+ *
+ * 2 variantes :
+ * - `mode="auto"` : la saisie filtre instantanément (émet `valueChange` à chaque caractère)
+ * - `mode="manual"` : champ + bouton "Rechercher" qui déclenche `search` (utile pour API distantes)
+ *
+ * Texte d'aide placé AVANT le champ (accessibilité — lecteurs d'écran).
+ *
+ * @example Auto-filtre
+ * <app-search-bar
+ *   [(value)]="query"
+ *   placeholder="Rechercher un site...">
+ * </app-search-bar>
+ *
+ * @example Manuel (avec bouton)
+ * <app-search-bar
+ *   mode="manual"
+ *   placeholder="Rechercher un plan..."
+ *   helpText="Entrez au moins 2 caractères"
+ *   (search)="onSearch($event)">
+ * </app-search-bar>
+ */
+@Component({
+  selector: 'app-search-bar',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TranslateModule],
+  templateUrl: './search-bar.component.html',
+  styleUrl: './search-bar.component.scss',
+})
+export class SearchBarComponent {
+  /** Mode de la barre : 'auto' (filtre instantané) ou 'manual' (avec bouton) */
+  @Input() mode: SearchBarMode = 'auto';
+
+  /** Valeur courante du champ (two-way binding) */
+  @Input() value: string = '';
+  @Output() valueChange = new EventEmitter<string>();
+
+  /** Placeholder affiché dans le champ */
+  @Input() placeholder: string = '';
+
+  /** Texte d'aide affiché AU-DESSUS du champ (accessibilité) */
+  @Input() helpText?: string;
+
+  /** Label visuellement caché mais lu par les lecteurs d'écran si pas de helpText */
+  @Input() ariaLabel: string = 'Rechercher';
+
+  /** Désactive le champ */
+  @Input() disabled: boolean = false;
+
+  /** Émis en mode 'manual' quand l'utilisateur clique sur "Rechercher" ou appuie sur Enter */
+  @Output() search = new EventEmitter<string>();
+
+  /** Émis quand l'utilisateur efface le champ via le bouton x */
+  @Output() cleared = new EventEmitter<void>();
+
+  @ViewChild('input') input?: ElementRef<HTMLInputElement>;
+
+  protected hasFocus = signal(false);
+
+  onInput(newValue: string): void {
+    this.value = newValue;
+    if (this.mode === 'auto') {
+      this.valueChange.emit(newValue);
+    }
+  }
+
+  onEnter(): void {
+    if (this.mode === 'manual' && this.value.trim()) {
+      this.search.emit(this.value.trim());
+    }
+  }
+
+  onSearchClick(): void {
+    if (this.value.trim()) {
+      this.search.emit(this.value.trim());
+    }
+  }
+
+  clear(): void {
+    this.value = '';
+    this.valueChange.emit('');
+    this.cleared.emit();
+    this.input?.nativeElement.focus();
+  }
+
+  onFocus(): void {
+    this.hasFocus.set(true);
+  }
+
+  onBlur(): void {
+    this.hasFocus.set(false);
+  }
+}

--- a/frontend/src/app/shared/components/stepper/stepper.component.html
+++ b/frontend/src/app/shared/components/stepper/stepper.component.html
@@ -1,0 +1,28 @@
+<ol class="app-stepper">
+  @for (step of steps; track step.id; let i = $index, isLast = $last) {
+    <li
+      class="app-stepper__step"
+      [class.app-stepper__step--completed]="isCompleted(step, i)"
+      [class.app-stepper__step--current]="isCurrent(step)"
+      [class.app-stepper__step--clickable]="isClickable(step, i)"
+      [attr.aria-current]="isCurrent(step) ? 'step' : null">
+      <button
+        type="button"
+        class="app-stepper__node"
+        [disabled]="!isClickable(step, i)"
+        (click)="onClick(step, i)">
+        <span class="app-stepper__circle" aria-hidden="true">
+          @if (isCompleted(step, i)) {
+            <i class="fi fi-rr-check"></i>
+          } @else {
+            {{ i + 1 }}
+          }
+        </span>
+        <span class="app-stepper__label">{{ step.label }}</span>
+      </button>
+      @if (!isLast) {
+        <span class="app-stepper__line" [class.app-stepper__line--done]="isCompleted(step, i)" aria-hidden="true"></span>
+      }
+    </li>
+  }
+</ol>

--- a/frontend/src/app/shared/components/stepper/stepper.component.scss
+++ b/frontend/src/app/shared/components/stepper/stepper.component.scss
@@ -1,0 +1,114 @@
+@import 'variables';
+
+// Stepper (issue #301)
+
+.app-stepper {
+  display: flex;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-family: $font-family;
+  width: 100%;
+  gap: 0;
+
+  &__step {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    min-width: 0;
+
+    &:last-child {
+      flex: 0 0 auto;
+    }
+  }
+
+  &__node {
+    display: inline-flex;
+    align-items: center;
+    gap: $spacing-xs;
+    padding: 0;
+    background: transparent;
+    border: none;
+    cursor: default;
+    text-align: left;
+    color: $gray-dark;
+
+    &:disabled {
+      cursor: default;
+    }
+  }
+
+  &__circle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background-color: $white;
+    border: 1.5px solid $gray;
+    color: $gray-dark;
+    font-size: $font-size-small;
+    font-weight: $font-weight-bold;
+    line-height: 1;
+    flex-shrink: 0;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+
+    i {
+      font-size: 14px;
+      color: inherit;
+    }
+  }
+
+  &__label {
+    font-size: $font-size-small;
+    font-weight: $font-weight-semibold;
+    color: inherit;
+    line-height: 1.3;
+    white-space: nowrap;
+  }
+
+  &__line {
+    flex: 1;
+    height: 2px;
+    margin: 0 $spacing-sm;
+    background-color: $gray-light;
+    border-radius: 1px;
+    transition: background-color 0.2s ease;
+
+    &--done {
+      background-color: $primary-color;
+    }
+  }
+
+  // États
+  &__step--completed &__circle {
+    background-color: $primary-color;
+    border-color: $primary-color;
+    color: $white;
+  }
+
+  &__step--completed &__node {
+    color: $primary-color;
+  }
+
+  &__step--current &__circle {
+    background-color: $white;
+    border-color: $primary-color;
+    color: $primary-color;
+    box-shadow: 0 0 0 3px rgba($primary-color, 0.15);
+  }
+
+  &__step--current &__node {
+    color: $primary-color;
+  }
+
+  &__step--clickable &__node {
+    cursor: pointer;
+
+    &:hover .app-stepper__circle {
+      transform: scale(1.05);
+    }
+  }
+}

--- a/frontend/src/app/shared/components/stepper/stepper.component.ts
+++ b/frontend/src/app/shared/components/stepper/stepper.component.ts
@@ -1,0 +1,84 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export interface StepperStep {
+  /** Identifiant unique de l'étape */
+  id: string | number;
+  /** Label de l'étape (ex: "Fichier", "Correspondance") */
+  label: string;
+  /** Optionnel : étape terminée avec succès */
+  completed?: boolean;
+}
+
+/**
+ * Stepper - Composant étapes numérotées (issue #301)
+ *
+ * Utilisé pour les processus multi-étapes (ex: Import en masse de sites).
+ *
+ * - Étapes numérotées avec cercle
+ * - Ligne de progression entre étapes
+ * - État `completed` (check) / `current` (mise en avant) / `pending` (numéro)
+ * - Cliquable pour revenir en arrière sur étapes complétées
+ *
+ * @example
+ * <app-stepper
+ *   [steps]="[
+ *     { id: 1, label: 'Fichier', completed: true },
+ *     { id: 2, label: 'Correspondance', completed: true },
+ *     { id: 3, label: 'Vérification' },
+ *     { id: 4, label: 'Résultats' }
+ *   ]"
+ *   [currentStep]="3"
+ *   (stepClick)="goToStep($event)">
+ * </app-stepper>
+ */
+@Component({
+  selector: 'app-stepper',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './stepper.component.html',
+  styleUrl: './stepper.component.scss',
+})
+export class StepperComponent {
+  /** Liste des étapes */
+  @Input() steps: StepperStep[] = [];
+
+  /** Index (1-based) ou ID de l'étape courante */
+  @Input() currentStep: string | number = 1;
+
+  /** Si true, les étapes complétées sont cliquables (retour en arrière) */
+  @Input() allowGoBack: boolean = true;
+
+  /** Émis au clic sur une étape complétée */
+  @Output() stepClick = new EventEmitter<StepperStep>();
+
+  isCompleted(step: StepperStep, index: number): boolean {
+    if (step.completed !== undefined) {
+      return step.completed;
+    }
+    // Fallback: si pas explicite, complétée = avant l'étape courante
+    return this.indexOfStep(this.currentStep) > index;
+  }
+
+  isCurrent(step: StepperStep): boolean {
+    return step.id === this.currentStep || this.steps.indexOf(step) + 1 === this.currentStep;
+  }
+
+  isClickable(step: StepperStep, index: number): boolean {
+    return this.allowGoBack && this.isCompleted(step, index) && !this.isCurrent(step);
+  }
+
+  onClick(step: StepperStep, index: number): void {
+    if (this.isClickable(step, index)) {
+      this.stepClick.emit(step);
+    }
+  }
+
+  protected indexOfStep(stepIdOrIndex: string | number): number {
+    const byId = this.steps.findIndex((s) => s.id === stepIdOrIndex);
+    if (byId !== -1) {
+      return byId;
+    }
+    return typeof stepIdOrIndex === 'number' ? stepIdOrIndex - 1 : -1;
+  }
+}

--- a/frontend/src/app/shared/components/taxon-autocomplete/taxon-autocomplete.component.html
+++ b/frontend/src/app/shared/components/taxon-autocomplete/taxon-autocomplete.component.html
@@ -1,5 +1,6 @@
-<mat-form-field appearance="outline" class="taxon-autocomplete-field">
-  <mat-label>{{ label() }}</mat-label>
+<label class="app-mat-label">{{ label() }}</label>
+      <mat-form-field class="app-mat-form-field taxon-autocomplete-field" appearance="outline">>
+  <mat-label></mat-label>
   <input
     matInput
     [formControl]="searchControl"

--- a/frontend/src/app/shared/index.ts
+++ b/frontend/src/app/shared/index.ts
@@ -3,6 +3,15 @@ export * from './components/header/header.component';
 export * from './components/navigation-tile/navigation-tile.component';
 export * from './components/ellipse-icon-button/ellipse-icon-button.component';
 
+// Kit UI components (issues #298-#304)
+export * from './components/search-bar/search-bar.component';
+export * from './components/checkbox/checkbox.component';
+export * from './components/form-field/form-field.component';
+export * from './components/stepper/stepper.component';
+export * from './components/entity-tile/entity-tile.component';
+export * from './components/accordion/accordion.component';
+export * from './components/anchor-nav/anchor-nav.component';
+
 // Icons
 export * from './components/icons/score-icon.component';
 export * from './components/icons/action-icon.component';

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -23,7 +23,8 @@
       "select": "Sélectionner",
       "moveUp": "Monter",
       "moveDown": "Descendre",
-      "collapse": "Replier"
+      "collapse": "Replier",
+      "clear": "Effacer"
     },
     "status": {
       "active": "Actif",

--- a/frontend/src/assets/scss/_material-overrides.scss
+++ b/frontend/src/assets/scss/_material-overrides.scss
@@ -378,6 +378,81 @@ a[mat-raised-button][color="primary"] {
   }
 }
 
+// ============================================
+// FORM FIELD COMPACT (.app-mat-form-field)
+// ============================================
+// Style mat-form-field pour qu'il ressemble à <app-form-field> :
+// - Label au-dessus (pas flottant)
+// - Champ compact (~38px de hauteur)
+// - Suit le kit UI design system
+// À utiliser sur les mat-form-field qui contiennent mat-select/datepicker/autocomplete
+// (ces directives requièrent mat-form-field, donc on ne peut pas migrer vers app-form-field).
+
+.mat-mdc-form-field.app-mat-form-field {
+  // Outline
+  &.mat-form-field-appearance-outline {
+    .mat-mdc-text-field-wrapper {
+      background-color: $white;
+      border-radius: $border-radius-sm !important;
+      padding: 0;
+    }
+
+    // Cache l'encoche d'étiquette flottante
+    .mat-mdc-notched-outline {
+      .mdc-notched-outline__notch {
+        border-right: none !important;
+      }
+    }
+
+    // Cache le label flottant Material
+    .mat-mdc-floating-label,
+    .mdc-floating-label {
+      display: none !important;
+    }
+  }
+
+  // Hauteur compacte
+  .mat-mdc-form-field-infix {
+    padding-top: 6px !important;
+    padding-bottom: 6px !important;
+    min-height: 34px !important;
+  }
+
+  // Wrapper sans le souscrit (hint/error pris en charge par .form-error-msg / mat-hint séparés)
+  .mat-mdc-form-field-subscript-wrapper {
+    padding: 4px 0 0 0;
+
+    .mat-mdc-form-field-hint-wrapper,
+    .mat-mdc-form-field-error-wrapper {
+      padding: 0;
+    }
+  }
+
+  .mat-mdc-form-field-hint {
+    color: $gray-dark;
+    font-size: 12px;
+    line-height: 1.3;
+  }
+}
+
+// Label "app-form-field-style" au-dessus du mat-form-field
+.app-mat-label {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  font-family: $font-family;
+  font-size: $font-size-small;
+  font-weight: $font-weight-semibold;
+  color: $black;
+  line-height: 1.3;
+  margin-bottom: 4px;
+
+  .required-star {
+    color: $error-color;
+    font-weight: $font-weight-bold;
+  }
+}
+
 // Select dropdowns
 .mat-mdc-select {
   font-family: $font-family !important;


### PR DESCRIPTION
## Summary

Deuxième PR de la revue design Amandine 20/05/2026 (EPIC #293) — **création des 7 composants kit UI + migration intensive des usages existants**.

Branche basée sur `develop` (la phase A #320 n'est pas mergée mais les changements sont indépendants).

## Composants créés (7)

Tous **standalone**, documentés dans `CLAUDE.md`, exportés depuis `shared/index.ts`.

| # | Composant | Sélecteur |
|---|---|---|
| #298 | `SearchBarComponent` | `app-search-bar` (mode `auto`/`manual`) |
| #299 | `CheckboxComponent` | `app-checkbox` (avec variante `mention`) |
| #300 | `FormFieldComponent` | `app-form-field` (label au-dessus) |
| #301 | `StepperComponent` | `app-stepper` |
| #302 | `EntityTileComponent` | `app-entity-tile` (avec `routerLink`, `locked`, slot) |
| #303 | `AccordionComponent` | `app-accordion` (variantes default/enjeu/fcr/subtle) |
| #304 | `AnchorNavComponent` | `app-anchor-nav` (scroll smooth) |

## Migrations effectuées

### Stepper (#301) — 1 place
- `bulk-site-import-modal` (4 étapes : Fichier/Correspondance/Vérification/Résultats)

### AnchorNav (#304) — 1 page
- `site-detail` : sidebar verticale → anchor-nav horizontal. **UX change** : toutes les sections sont désormais affichées en même temps (scroll au lieu de switch)

### EntityTile (#302) — 5 places
- `plan-detail` : sites cliquables + verrouillés + pending + membres
- `site-detail` : utilisateurs du site

### SearchBar (#298) — 10 places
- 5 pages admin : users, organismes, plans, sites, redacteurs-principaux
- `sites-list`, `plans-list` (2 places), `inventaires-list`, `activity` (mode=manual), `plan-create`

### Checkbox (#299) — ~45 places
- `duplicate-plan-dialog` (5 avec mention)
- `enjeu-form` (13)
- `enjeux-list` (12)
- `operation-form` (3)
- `site-form-modal` (4)
- `find-or-create-site-modal` (3)
- `csrpn-step-dialog` (1)
- `plan-form-modal` (1)
- `plan-create` (1)

### Accordion (#303) — 2 places
- `enjeu-form` (variant="enjeu") : remplace mat-expansion-panel
- `fcr-form` (variant="fcr") : remplace mat-expansion-panel

### FormField (#300) — 1 showcase
- `deactivate-user-modal` : textarea avec label + helpText
- Migration massive (~180 cas) **différée en phase C** (chaque form a ses subtilités)

## Tests

✅ **55 suites / 1655 tests passent** — y compris specs mis à jour (site-detail, duplicate-plan-dialog)

## Migrations restantes (phase C, par section app)

| Composant | Restant | Détail |
|---|---|---|
| #300 FormField | ~252 | Migration manuelle par form (mat-error conditionnels, mat-hint multiples) ; les ~73 mat-form-field qui wrappent `mat-select`/`mat-datepicker`/`mat-autocomplete`/`mat-chip-list` doivent rester en Material |
| #299 Checkbox | ~4 | bulk-site-import (indeterminate), manage-site-users-modal (logique referent complexe) |
| #303 Accordion | ~10 | operation-form (7 sections), inventaire-form (3) — restructuration HTML risquée |
| #302 EntityTile | ~2 | manage-site-users-modal (pattern complexe avec multi-actions) |

## Cas particuliers laissés en Material

- `bulk-site-import-modal` mat-checkbox : utilise `[indeterminate]` non supporté par app-checkbox
- `manage-site-users-modal` : pattern user-card avec logique referent complexe
- `mat-form-field` wrappant `mat-select` etc. : Material directives requièrent MatFormField context

## Issues couvertes

- Closes #298, #299, #300, #301, #302, #303, #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)
